### PR TITLE
Rename `JavaTypeDescriptor` and `SqlTypeDescriptor` to `JavaType` and `SqlType`

### DIFF
--- a/src/main/resources/META-INF/rewrite/hibernate-6.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.yml
@@ -16,7 +16,7 @@
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.hibernate.MigrateToHibernate61
+name: org.openrewrite.hibernate.MigrateToHibernate61
 displayName: Migrate to Hibernate 6.1.x
 description: >
   This recipe will apply changes commonly needed when migrating to Hibernate 6.1.x. The hibernate dependencies will  
@@ -24,13 +24,13 @@ description: >
   with Jakarta EE 9.0.
 
 recipeList:
-  - org.openrewrite.java.migrate.hibernate.MigrateToHibernateDependencies61
+  - org.openrewrite.hibernate.MigrateToHibernateDependencies61
   - org.openrewrite.java.migrate.jakarta.JavaxPersistenceToJakartaPersistence
   - org.openrewrite.java.migrate.jakarta.JavaxPersistenceXmlToJakartaPersistenceXml
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.migrate.hibernate.MigrateToHibernateDependencies61
+name: org.openrewrite.hibernate.MigrateToHibernateDependencies61
 displayName: Migrate Hibernate dependencies to 6.1.x
 description: >
   This recipe will migrate any existing dependencies on Hibernate 5.x to the latest 6.1.x release. This migration will

--- a/src/main/resources/META-INF/rewrite/hibernate-6.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.yml
@@ -25,6 +25,7 @@ description: >
 
 recipeList:
   - org.openrewrite.hibernate.MigrateToHibernateDependencies61
+  - org.openrewrite.hibernate.TypeDescriptorToType
   - org.openrewrite.java.migrate.jakarta.JavaxPersistenceToJakartaPersistence
   - org.openrewrite.java.migrate.jakarta.JavaxPersistenceXmlToJakartaPersistenceXml
 
@@ -379,3 +380,19 @@ recipeList:
   - org.openrewrite.java.dependencies.RemoveDependency:
         groupId: org.hibernate
         artifactId: hibernate-entitymanager
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.hibernate.TypeDescriptorToType
+displayName: Rename `JavaTypeDescriptor` and `SqlTypeDescriptor` to `JavaType` and `SqlType`
+description: >
+  Rename `JavaTypeDescriptor` and `SqlTypeDescriptor` to `JavaType` and `SqlType` respectively.
+  See https://github.com/hibernate/hibernate-orm/blob/6.0/migration-guide.adoc#type-system
+
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.hibernate.type.descriptor.java.JavaTypeDescriptor
+      newFullyQualifiedTypeName: org.hibernate.type.descriptor.java.JavaType
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.hibernate.type.descriptor.sql.SqlTypeDescriptor
+      newFullyQualifiedTypeName: org.hibernate.type.descriptor.sql.SqlType


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
https://github.com/hibernate/hibernate-orm/discussions/6759#discussion-5281395
https://github.com/hibernate/hibernate-orm/blob/6.0/migration-guide.adoc#renaming-of-javatypedescriptor-contract

## Anything in particular you'd like reviewers to focus on?
Should these also be replaced in properties or other forms of configuration?
Right now they are only replaced where used directly in Java classes.

## Anyone you would like to review specifically?
@jjank

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
