### PR TITLE
chore: [issue#4] add recipe for migrating `com.vladmihalcea:hibernate-types` to `io.hypersistence:hypersistence-utils-hibernate-6X`

### DIFF
--- a/src/main/resources/META-INF/rewrite/hibernate-6.2.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.2.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 the original author or authors.
+# Copyright 2023 the original author or authors.
 # <p>
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/rewrite/hibernate-6.2.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.2.yml
@@ -39,5 +39,5 @@ recipeList:
       oldArtifactId: hypersistence-utils-hibernate-60
       newGroupId: io.hypersistence
       newArtifactId: hypersistence-utils-hibernate-62
-      newVersion: 3.4.x
+      newVersion: 3.5.x
 

--- a/src/main/resources/META-INF/rewrite/hibernate-6.2.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.2.yml
@@ -1,0 +1,43 @@
+#
+# Copyright 2021 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.hibernate.MigrateToHibernate62
+displayName: Migrate to Hibernate 6.2.x
+description: >
+  This recipe will apply changes commonly needed when migrating to Hibernate 6.2.x.
+
+recipeList:
+  - org.openrewrite.hibernate.MigrateToHibernate61
+  - org.openrewrite.hibernate.MigrateToHypersistenceUtilsHibernate6.2
+
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.hibernate.MigrateToHypersistenceUtilsHibernate6.2
+displayName: Migrate Hibernate Types to Hypersistence Utils 6.2
+description: >
+  This recipe will migrate any existing dependencies on `io.hypersistence:hypersistence-utils-hibernate-60` to `io.hypersistence:hypersistence-utils-hibernate-62`. 
+
+recipeList:
+  - org.openrewrite.java.dependencies.ChangeDependency:
+        oldGroupId: io.hypersistence
+        oldArtifactId: hypersistence-utils-hibernate-60
+        newGroupId: io.hypersistence
+        newArtifactId: hypersistence-utils-hibernate-62
+        newVersion: 3.4.x
+

--- a/src/main/resources/META-INF/rewrite/hibernate-6.2.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.2.yml
@@ -35,9 +35,9 @@ description: >
 
 recipeList:
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: io.hypersistence
-        oldArtifactId: hypersistence-utils-hibernate-60
-        newGroupId: io.hypersistence
-        newArtifactId: hypersistence-utils-hibernate-62
-        newVersion: 3.4.x
+      oldGroupId: io.hypersistence
+      oldArtifactId: hypersistence-utils-hibernate-60
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-62
+      newVersion: 3.4.x
 

--- a/src/main/resources/META-INF/rewrite/hibernate-6.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.yml
@@ -28,6 +28,7 @@ recipeList:
   - org.openrewrite.hibernate.TypeDescriptorToType
   - org.openrewrite.java.migrate.jakarta.JavaxPersistenceToJakartaPersistence
   - org.openrewrite.java.migrate.jakarta.JavaxPersistenceXmlToJakartaPersistenceXml
+  - org.openrewrite.hibernate.MigrateToHypersistenceUtilsHibernate6.0
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -391,8 +392,58 @@ description: >
 
 recipeList:
   - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.hibernate.type.descriptor.java.JavaTypeDescriptor
-      newFullyQualifiedTypeName: org.hibernate.type.descriptor.java.JavaType
+        oldFullyQualifiedTypeName: org.hibernate.type.descriptor.java.JavaTypeDescriptor
+        newFullyQualifiedTypeName: org.hibernate.type.descriptor.java.JavaType
   - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.hibernate.type.descriptor.sql.SqlTypeDescriptor
-      newFullyQualifiedTypeName: org.hibernate.type.descriptor.sql.SqlType
+        oldFullyQualifiedTypeName: org.hibernate.type.descriptor.sql.SqlTypeDescriptor
+        newFullyQualifiedTypeName: org.hibernate.type.descriptor.sql.SqlType
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.hibernate.MigrateToHypersistenceUtilsHibernate6.0
+displayName: Migrate Hibernate Types to Hypersistence Utils 6.0
+description: >
+  This recipe will migrate any existing dependencies on `com.vladmihalcea:hibernate-types` to `io.hypersistence:hypersistence-utils-hibernate-60`. 
+  This migration will include the adjustment from `com.vladmihalcea` to `io.hypersistence.utils` package name.
+
+recipeList:
+  - org.openrewrite.java.dependencies.ChangeDependency:
+        oldGroupId: com.vladmihalcea
+        oldArtifactId: hibernate-types-4
+        newGroupId: io.hypersistence
+        newArtifactId: hypersistence-utils-hibernate-60
+        newVersion: 3.4.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+        oldGroupId: com.vladmihalcea
+        oldArtifactId: hibernate-types-5
+        newGroupId: io.hypersistence
+        newArtifactId: hypersistence-utils-hibernate-60
+        newVersion: 3.4.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+        oldGroupId: com.vladmihalcea
+        oldArtifactId: hibernate-types-43
+        newGroupId: io.hypersistence
+        newArtifactId: hypersistence-utils-hibernate-60
+        newVersion: 3.4.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+        oldGroupId: com.vladmihalcea
+        oldArtifactId: hibernate-types-52
+        newGroupId: io.hypersistence
+        newArtifactId: hypersistence-utils-hibernate-60
+        newVersion: 3.4.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+        oldGroupId: com.vladmihalcea
+        oldArtifactId: hibernate-types-55
+        newGroupId: io.hypersistence
+        newArtifactId: hypersistence-utils-hibernate-60
+        newVersion: 3.4.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+        oldGroupId: com.vladmihalcea
+        oldArtifactId: hibernate-types-60
+        newGroupId: io.hypersistence
+        newArtifactId: hypersistence-utils-hibernate-60
+        newVersion: 3.4.x
+  - org.openrewrite.java.ChangePackage:
+        oldPackageName: com.vladmihalcea
+        newPackageName: io.hypersistence.utils
+        recursive: true

--- a/src/main/resources/META-INF/rewrite/hibernate-6.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.yml
@@ -42,345 +42,345 @@ description: >
 recipeList:
   # hibernate-agroal
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-agroal
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-agroal
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-agroal
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-agroal
+      newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-agroal-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-agroal
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-agroal-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-agroal
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-agroal
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-agroal
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-agroal
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-agroal
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-agroal-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-agroal
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-agroal-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-agroal
+      newVersion: 6.1.x
   # hibernate-c3p0
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-c3p0
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-c3p0
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-c3p0
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-c3p0
+      newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-c3p0-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-c3p0
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-c3p0-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-c3p0
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-c3p0
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-c3p0
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-c3p0
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-c3p0
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-c3p0-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-c3p0
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-c3p0-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-c3p0
+      newVersion: 6.1.x
     # hibernate-community-dialects
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-community-dialects
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-community-dialects
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-community-dialects
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-community-dialects
+      newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-community-dialects-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-community-dialects
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-community-dialects-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-community-dialects
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-community-dialects
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-community-dialects
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-community-dialects
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-community-dialects
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-community-dialects-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-community-dialects
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-community-dialects-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-community-dialects
+      newVersion: 6.1.x
     # hibernate-core
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-core
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-core
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-core
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-core
+      newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-core-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-core
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-core-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-core
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-core
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-core
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-core
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-core
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-core-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-core
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-core-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-core
+      newVersion: 6.1.x
     # hibernate-envers
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-envers
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-envers
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-envers
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-envers
+      newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-envers-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-envers
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-envers-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-envers
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-envers
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-envers
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-envers
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-envers
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-envers-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-envers
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-envers-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-envers
+      newVersion: 6.1.x
     # hibernate-graalvm
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-graalvm
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-graalvm
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-graalvm
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-graalvm
+      newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-graalvm-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-graalvm
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-graalvm-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-graalvm
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-graalvm
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-graalvm
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-graalvm
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-graalvm
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-graalvm-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-graalvm
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-graalvm-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-graalvm
+      newVersion: 6.1.x
     # hibernate-hikaricp
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-hikaricp
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-hikaricp
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-hikaricp
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-hikaricp
+      newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-hikaricp-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-hikaricp
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-hikaricp-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-hikaricp
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-hikaricp
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-hikaricp
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-hikaricp
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-hikaricp
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-hikaricp-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-hikaricp
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-hikaricp-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-hikaricp
+      newVersion: 6.1.x
     # hibernate-jcache
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-jcache
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-jcache
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-jcache
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-jcache
+      newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-jcache-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-jcache
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-jcache-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-jcache
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-jcache
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-jcache
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-jcache
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-jcache
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-jcache-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-jcache
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-jcache-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-jcache
+      newVersion: 6.1.x
     # hibernate-jpamodelgen
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-jpamodelgen
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-jpamodelgen
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-jpamodelgen
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-jpamodelgen
+      newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-jpamodelgen-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-jpamodelgen
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-jpamodelgen-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-jpamodelgen
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-jpamodelgen
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-jpamodelgen
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-jpamodelgen
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-jpamodelgen
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-jpamodelgen-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-jpamodelgen
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-jpamodelgen-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-jpamodelgen
+      newVersion: 6.1.x
     # hibernate-micrometer
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-micrometer
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-micrometer
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-micrometer
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-micrometer
+      newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-micrometer-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-micrometer
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-micrometer-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-micrometer
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-micrometer
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-micrometer
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-micrometer
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-micrometer
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-micrometer-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-micrometer
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-micrometer-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-micrometer
+      newVersion: 6.1.x
     # hibernate-proxool
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-proxool
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-proxool
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-proxool
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-proxool
+      newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-proxool-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-proxool
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-proxool-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-proxool
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-proxool
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-proxool
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-proxool
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-proxool
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-proxool-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-proxool
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-proxool-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-proxool
+      newVersion: 6.1.x
     # hibernate-spatial
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-spatial
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-spatial
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-spatial
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-spatial
+      newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-spatial-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-spatial
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-spatial-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-spatial
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-spatial
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-spatial
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-spatial
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-spatial
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-spatial-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-spatial
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-spatial-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-spatial
+      newVersion: 6.1.x
     # hibernate-testing
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-testing
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-testing
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-testing
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-testing
+      newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-testing-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-testing
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-testing-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-testing
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-testing
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-testing
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-testing
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-testing
+      newVersion: 6.1.x
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-testing-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-testing
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-testing-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-testing
+      newVersion: 6.1.x
     # hibernate-testing
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-testing
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-testing
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-testing
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-testing
+      newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: org.hibernate
-        oldArtifactId: hibernate-testing-jakarta
-        newGroupId: org.hibernate.orm
-        newArtifactId: hibernate-testing
-        newVersion: 6.1.x
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-testing-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-testing
+      newVersion: 6.1.x
   - org.openrewrite.java.dependencies.RemoveDependency:
-        groupId: org.hibernate
-        artifactId: hibernate-entitymanager
+      groupId: org.hibernate
+      artifactId: hibernate-entitymanager
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -392,11 +392,11 @@ description: >
 
 recipeList:
   - org.openrewrite.java.ChangeType:
-        oldFullyQualifiedTypeName: org.hibernate.type.descriptor.java.JavaTypeDescriptor
-        newFullyQualifiedTypeName: org.hibernate.type.descriptor.java.JavaType
+      oldFullyQualifiedTypeName: org.hibernate.type.descriptor.java.JavaTypeDescriptor
+      newFullyQualifiedTypeName: org.hibernate.type.descriptor.java.JavaType
   - org.openrewrite.java.ChangeType:
-        oldFullyQualifiedTypeName: org.hibernate.type.descriptor.sql.SqlTypeDescriptor
-        newFullyQualifiedTypeName: org.hibernate.type.descriptor.sql.SqlType
+      oldFullyQualifiedTypeName: org.hibernate.type.descriptor.sql.SqlTypeDescriptor
+      newFullyQualifiedTypeName: org.hibernate.type.descriptor.sql.SqlType
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -408,42 +408,42 @@ description: >
 
 recipeList:
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: com.vladmihalcea
-        oldArtifactId: hibernate-types-4
-        newGroupId: io.hypersistence
-        newArtifactId: hypersistence-utils-hibernate-60
-        newVersion: 3.4.x
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-4
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-60
+      newVersion: 3.4.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: com.vladmihalcea
-        oldArtifactId: hibernate-types-5
-        newGroupId: io.hypersistence
-        newArtifactId: hypersistence-utils-hibernate-60
-        newVersion: 3.4.x
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-5
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-60
+      newVersion: 3.4.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: com.vladmihalcea
-        oldArtifactId: hibernate-types-43
-        newGroupId: io.hypersistence
-        newArtifactId: hypersistence-utils-hibernate-60
-        newVersion: 3.4.x
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-43
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-60
+      newVersion: 3.4.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: com.vladmihalcea
-        oldArtifactId: hibernate-types-52
-        newGroupId: io.hypersistence
-        newArtifactId: hypersistence-utils-hibernate-60
-        newVersion: 3.4.x
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-52
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-60
+      newVersion: 3.4.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: com.vladmihalcea
-        oldArtifactId: hibernate-types-55
-        newGroupId: io.hypersistence
-        newArtifactId: hypersistence-utils-hibernate-60
-        newVersion: 3.4.x
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-55
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-60
+      newVersion: 3.4.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-        oldGroupId: com.vladmihalcea
-        oldArtifactId: hibernate-types-60
-        newGroupId: io.hypersistence
-        newArtifactId: hypersistence-utils-hibernate-60
-        newVersion: 3.4.x
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-60
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-60
+      newVersion: 3.4.x
   - org.openrewrite.java.ChangePackage:
-        oldPackageName: com.vladmihalcea
-        newPackageName: io.hypersistence.utils
-        recursive: true
+      oldPackageName: com.vladmihalcea
+      newPackageName: io.hypersistence.utils
+      recursive: true

--- a/src/main/resources/META-INF/rewrite/hibernate-6.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.yml
@@ -412,37 +412,37 @@ recipeList:
       oldArtifactId: hibernate-types-4
       newGroupId: io.hypersistence
       newArtifactId: hypersistence-utils-hibernate-60
-      newVersion: 3.4.x
+      newVersion: 3.5.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.vladmihalcea
       oldArtifactId: hibernate-types-5
       newGroupId: io.hypersistence
       newArtifactId: hypersistence-utils-hibernate-60
-      newVersion: 3.4.x
+      newVersion: 3.5.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.vladmihalcea
       oldArtifactId: hibernate-types-43
       newGroupId: io.hypersistence
       newArtifactId: hypersistence-utils-hibernate-60
-      newVersion: 3.4.x
+      newVersion: 3.5.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.vladmihalcea
       oldArtifactId: hibernate-types-52
       newGroupId: io.hypersistence
       newArtifactId: hypersistence-utils-hibernate-60
-      newVersion: 3.4.x
+      newVersion: 3.5.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.vladmihalcea
       oldArtifactId: hibernate-types-55
       newGroupId: io.hypersistence
       newArtifactId: hypersistence-utils-hibernate-60
-      newVersion: 3.4.x
+      newVersion: 3.5.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.vladmihalcea
       oldArtifactId: hibernate-types-60
       newGroupId: io.hypersistence
       newArtifactId: hypersistence-utils-hibernate-60
-      newVersion: 3.4.x
+      newVersion: 3.5.x
   - org.openrewrite.java.ChangePackage:
       oldPackageName: com.vladmihalcea
       newPackageName: io.hypersistence.utils

--- a/src/test/java/org/openrewrite/hibernate/MigrateToHibernate61Test.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateToHibernate61Test.java
@@ -91,4 +91,69 @@ class MigrateToHibernate61Test implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void groupIdHypersistenceUtilsRenamedAndPackageUpdated() {
+        rewriteRun(
+          mavenProject(
+            "Sample",
+            //language=xml
+            pomXml("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>demo</artifactId>
+                  <version>0.0.1-SNAPSHOT</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>com.vladmihalcea</groupId>
+                      <artifactId>hibernate-types-52</artifactId>
+                      <version>2.17.1</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """, spec -> spec.after(actual -> {
+                Matcher matcher = Pattern.compile("<version>(3\\.4\\.\\d+)</version>").matcher(actual);
+                assertTrue(matcher.find());
+                return """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>demo</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>io.hypersistence</groupId>
+                        <artifactId>hypersistence-utils-hibernate-60</artifactId>
+                        <version>%s</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                    """.formatted(matcher.group(1));
+              })
+            ),
+            //language=java
+            srcMainJava(
+              java("""
+                import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+                
+                public class TestApplication {
+                }
+                """, spec -> spec.after(actual -> """
+                import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
+                                
+                public class TestApplication {
+                }
+                """)
+              )
+            )
+          )
+        );
+    }
+
+
 }

--- a/src/test/java/org/openrewrite/hibernate/MigrateToHibernate61Test.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateToHibernate61Test.java
@@ -115,7 +115,7 @@ class MigrateToHibernate61Test implements RewriteTest {
                   </dependencies>
                 </project>
                 """, spec -> spec.after(actual -> {
-                  Matcher matcher = Pattern.compile("<version>(3\\.4\\.\\d+)</version>").matcher(actual);
+                  Matcher matcher = Pattern.compile("<version>(3\\.5\\.\\d+)</version>").matcher(actual);
                   assertTrue(matcher.find());
                   return """
                     <?xml version="1.0" encoding="UTF-8"?>

--- a/src/test/java/org/openrewrite/hibernate/MigrateToHibernate61Test.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateToHibernate61Test.java
@@ -61,7 +61,7 @@ class MigrateToHibernate61Test implements RewriteTest {
                 """, spec -> spec.after(actual -> {
                   Matcher matcher = Pattern.compile("<version>(6\\.1\\.\\d+\\.Final)</version>").matcher(actual);
                   assertTrue(matcher.find());
-                return """
+                  return """
                     <?xml version="1.0" encoding="UTF-8"?>
                     <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                       xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -115,40 +115,40 @@ class MigrateToHibernate61Test implements RewriteTest {
                   </dependencies>
                 </project>
                 """, spec -> spec.after(actual -> {
-                Matcher matcher = Pattern.compile("<version>(3\\.4\\.\\d+)</version>").matcher(actual);
-                assertTrue(matcher.find());
-                return """
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>com.example</groupId>
-                    <artifactId>demo</artifactId>
-                    <version>0.0.1-SNAPSHOT</version>
-                    <dependencies>
-                      <dependency>
-                        <groupId>io.hypersistence</groupId>
-                        <artifactId>hypersistence-utils-hibernate-60</artifactId>
-                        <version>%s</version>
-                      </dependency>
-                    </dependencies>
-                  </project>
-                    """.formatted(matcher.group(1));
+                  Matcher matcher = Pattern.compile("<version>(3\\.4\\.\\d+)</version>").matcher(actual);
+                  assertTrue(matcher.find());
+                  return """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.example</groupId>
+                      <artifactId>demo</artifactId>
+                      <version>0.0.1-SNAPSHOT</version>
+                      <dependencies>
+                        <dependency>
+                          <groupId>io.hypersistence</groupId>
+                          <artifactId>hypersistence-utils-hibernate-60</artifactId>
+                          <version>%s</version>
+                        </dependency>
+                      </dependencies>
+                    </project>
+                      """.formatted(matcher.group(1));
               })
             ),
             //language=java
             srcMainJava(
               java("""
                 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
-                
+                                
                 public class TestApplication {
                 }
-                """, spec -> spec.after(actual -> """
+                """, """
                 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
                                 
                 public class TestApplication {
                 }
-                """)
+                """
               )
             )
           )


### PR DESCRIPTION
## What's changed?
Adding recipe for https://github.com/openrewrite/rewrite-hibernate/issues/4 and a placeholder for Hibernate 6.2 recipe.

## What's your motivation?
See https://github.com/openrewrite/rewrite-hibernate/issues/4 issue description.

## Any additional context
I consider `org.openrewrite.hibernate.MigrateToHibernate62` a placeholder and adding more recipes to be out of the scope from this issue.

### Checklist
- [:heavy_check_mark:] I've added unit tests to cover both positive and negative cases
- [:heavy_check_mark:] I've added the license header to any new files through `./gradlew licenseFormat`
- [:heavy_check_mark:] I've used the IntelliJ auto-formatter on affected files
- [:heavy_check_mark:] I've updated the documentation (if applicable)
