### PR TITLE
Type Annotation type parameter replaced by value parameter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,4 +19,7 @@ dependencies {
     testImplementation("org.openrewrite:rewrite-maven")
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine:latest.release")
+
+    testRuntimeOnly("org.hibernate:hibernate-core:5.6.15.Final")
+
 }

--- a/src/main/java/org/openrewrite/hibernate/TypeAnnotationParameter.java
+++ b/src/main/java/org/openrewrite/hibernate/TypeAnnotationParameter.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.hibernate;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
+
+import java.util.Collections;
+
+public class TypeAnnotationParameter extends Recipe {
+
+    private static final String FQN_TYPE_ANNOTATION = "org.hibernate.annotations.Type";
+
+    @Override
+    public String getDisplayName() {
+        return "@Type annotation type parameter migration";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Hibernate 6.x has 'type' parameter of type String replaced with 'value' of type class.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext executionContext) {
+                J.Annotation a = super.visitAnnotation(annotation, executionContext);
+                JavaType.FullyQualified type = TypeUtils.asFullyQualified(a.getType());
+                if (type != null && FQN_TYPE_ANNOTATION.equals(type.getFullyQualifiedName())) {
+                    final boolean isOnlyParameter = a.getArguments().size() == 1;
+                    a = a.withArguments(ListUtils.map(a.getArguments(), arg -> {
+                       if (arg instanceof J.Assignment) {
+                           J.Assignment assignment = (J.Assignment) arg;
+                           if (assignment.getVariable() instanceof J.Identifier && "type".equals(((J.Identifier) assignment.getVariable()).getSimpleName())
+                                && assignment.getAssignment() instanceof J.Literal) {
+                               J.Identifier paramName = (J.Identifier) assignment.getVariable();
+                               String fqTypeName = (String) ((J.Literal) assignment.getAssignment()).getValue();
+                               String simpleTypeName = getSimpleName(fqTypeName);
+                               JavaType typeOfNewValue = JavaType.buildType(fqTypeName);
+                               J.FieldAccess fa = new J.FieldAccess(
+                                       Tree.randomId(),
+                                       isOnlyParameter ? Space.EMPTY : assignment.getAssignment().getPrefix(),
+                                       assignment.getAssignment().getMarkers(),
+                                       new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(), simpleTypeName, typeOfNewValue, null),
+                                       JLeftPadded.build(new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(), "class", null, null)),
+                                       JavaType.buildType("java.lang.Class")
+                               );
+                               maybeAddImport(fqTypeName);
+                               autoFormat(assignment, executionContext);
+                               if (isOnlyParameter) {
+                                   return fa;
+                               } else {
+                                   return assignment.withVariable(paramName.withSimpleName("value")).withAssignment(fa);
+                               }
+                           }
+                       }
+                       return arg;
+                    }));
+                }
+                return a;
+            }
+        };
+    }
+
+    private static String getSimpleName(String fqName) {
+        int idx = fqName.lastIndexOf('.');
+        if (idx > 0 && idx < fqName.length() - 1) {
+            return fqName.substring(idx + 1);
+        }
+        return fqName;
+    }
+
+}

--- a/src/main/resources/META-INF/rewrite/hibernate-6.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.yml
@@ -25,6 +25,7 @@ description: >
 
 recipeList:
   - org.openrewrite.hibernate.MigrateToHibernateDependencies61
+  - org.openrewrite.hibernate.TypeAnnotationParameter
   - org.openrewrite.hibernate.TypeDescriptorToType
   - org.openrewrite.java.migrate.jakarta.JavaxPersistenceToJakartaPersistence
   - org.openrewrite.java.migrate.jakarta.JavaxPersistenceXmlToJakartaPersistenceXml

--- a/src/test/java/org/openrewrite/hibernate/TypeAnnotationParameterTest.java
+++ b/src/test/java/org/openrewrite/hibernate/TypeAnnotationParameterTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.hibernate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class TypeAnnotationParameterTest implements RewriteTest {
+
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new TypeAnnotationParameter()).parser(JavaParser.fromJavaVersion().classpath("hibernate-core"));;
+    }
+
+    @Test
+    void onlyOneParameter() {
+        rewriteRun(
+              java("""
+                import org.hibernate.annotations.Type;
+                
+                public class TestApplication {
+                
+                    @Type(type = "java.util.concurrent.atomic.AtomicBoolean")
+                    Object a;
+                    
+                }
+                """,
+                """
+                import org.hibernate.annotations.Type;
+                
+                import java.util.concurrent.atomic.AtomicBoolean;
+                
+                public class TestApplication {
+                
+                    @Type(AtomicBoolean.class)
+                    Object a;
+                    
+                }
+                """
+              )
+          );
+    }
+
+    @Test
+    void multipleParameters() {
+        rewriteRun(
+          java("""
+                import org.hibernate.annotations.Type;
+                
+                public class TestApplication {
+                
+                    @Type(type = "java.util.concurrent.atomic.AtomicBoolean", parameters = {})
+                    Object a;
+                    
+                }
+                """,
+            """
+            import org.hibernate.annotations.Type;
+            
+            import java.util.concurrent.atomic.AtomicBoolean;
+            
+            public class TestApplication {
+            
+                @Type(value = AtomicBoolean.class, parameters = {})
+                Object a;
+                
+            }
+            """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/hibernate/TypeAnnotationParameterTest.java
+++ b/src/test/java/org/openrewrite/hibernate/TypeAnnotationParameterTest.java
@@ -25,63 +25,57 @@ import static org.openrewrite.java.Assertions.java;
 public class TypeAnnotationParameterTest implements RewriteTest {
 
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new TypeAnnotationParameter()).parser(JavaParser.fromJavaVersion().classpath("hibernate-core"));;
+        spec.recipe(new TypeAnnotationParameter()).parser(JavaParser.fromJavaVersion().classpath("hibernate-core"));
     }
 
     @Test
     void onlyOneParameter() {
         rewriteRun(
-              java("""
-                import org.hibernate.annotations.Type;
-                
-                public class TestApplication {
-                
-                    @Type(type = "java.util.concurrent.atomic.AtomicBoolean")
-                    Object a;
-                    
-                }
-                """,
-                """
-                import org.hibernate.annotations.Type;
-                
-                import java.util.concurrent.atomic.AtomicBoolean;
-                
-                public class TestApplication {
-                
-                    @Type(AtomicBoolean.class)
-                    Object a;
-                    
-                }
-                """
-              )
-          );
+          //language=java
+          java("""
+              import org.hibernate.annotations.Type;
+              
+              public class TestApplication {
+                  @Type(type = "java.util.concurrent.atomic.AtomicBoolean")
+                  Object a;
+              }
+              """,
+            """
+              import org.hibernate.annotations.Type;
+              
+              import java.util.concurrent.atomic.AtomicBoolean;
+              
+              public class TestApplication {
+                  @Type(AtomicBoolean.class)
+                  Object a;
+              }
+              """
+          )
+        );
     }
 
     @Test
     void multipleParameters() {
         rewriteRun(
+          //language=java
           java("""
-                import org.hibernate.annotations.Type;
-                
-                public class TestApplication {
-                
-                    @Type(type = "java.util.concurrent.atomic.AtomicBoolean", parameters = {})
-                    Object a;
-                    
-                }
-                """,
+              import org.hibernate.annotations.Type;
+              
+              class TestApplication {
+                  @Type(type = "java.util.concurrent.atomic.AtomicBoolean", parameters = {})
+                  Object a;
+              }
+              """,
             """
-            import org.hibernate.annotations.Type;
-            
-            import java.util.concurrent.atomic.AtomicBoolean;
-            
-            public class TestApplication {
-            
-                @Type(value = AtomicBoolean.class, parameters = {})
-                Object a;
-                
-            }
-            """
+              import org.hibernate.annotations.Type;
+                          
+              import java.util.concurrent.atomic.AtomicBoolean;
+                          
+              class TestApplication {
+                  @Type(value = AtomicBoolean.class, parameters = {})
+                  Object a;
+              }
+              """
           )
         );
     }


### PR DESCRIPTION
Hibernate 5.x:
```
@Type(type = "my.great.UserType") 
```

Hibernate 6.x:
```
@Type(UserType.class)
```

I'd like to have this recipe while running Boot 2.x to 3.x upgrade. How can we make this happen? Is there Hibernate 5.x -> 6.x upgrade? 
