### PR TITLE
Adds recipe for migration of @LazyCollection

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,6 @@ dependencies {
     implementation("org.openrewrite:rewrite-java")
     implementation("org.openrewrite.recipe:rewrite-migrate-java:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-java-dependencies:$rewriteVersion")
-    implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
 
     testImplementation("org.openrewrite:rewrite-java-17")
     testImplementation("org.openrewrite:rewrite-test")
@@ -21,4 +20,5 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine:latest.release")
 
     testRuntimeOnly("org.hibernate:hibernate-core:5.6.15.Final")
+    testRuntimeOnly("jakarta.persistence:jakarta.persistence-api:3.1.0")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation("org.openrewrite:rewrite-java")
     implementation("org.openrewrite.recipe:rewrite-migrate-java:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-java-dependencies:$rewriteVersion")
+    implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
 
     testImplementation("org.openrewrite:rewrite-java-17")
     testImplementation("org.openrewrite:rewrite-test")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,5 +21,4 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine:latest.release")
 
     testRuntimeOnly("org.hibernate:hibernate-core:5.6.15.Final")
-
 }

--- a/src/main/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotation.java
+++ b/src/main/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotation.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2024 Schweizerische Bundesbahnen SBB
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openrewrite.hibernate;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JLeftPadded;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.marker.Markers;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class ReplaceLazyCollectionAnnotation extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Replace @LazyCollection with jakarta.persistence.FetchType";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Adds the FetchType to jakarta annotations and deletes @LazyCollection.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+
+            @Override
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                maybeAddImport("jakarta.persistence.FetchType");
+                maybeRemoveImport("org.hibernate.annotations.LazyCollection");
+                maybeRemoveImport("org.hibernate.annotations.LazyCollectionOption");
+                return super.visitCompilationUnit(cu, ctx);
+            }
+
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                final List<J.Annotation> annotations = removeLazyCollectionAnnotation(method.getLeadingAnnotations());
+                return super.visitMethodDeclaration(method.withLeadingAnnotations(annotations), ctx);
+            }
+
+            @Override
+            public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable,
+                    ExecutionContext ctx) {
+                final List<J.Annotation> annotations = removeLazyCollectionAnnotation(multiVariable.getLeadingAnnotations());
+                return super.visitVariableDeclarations(multiVariable.withLeadingAnnotations(annotations), ctx);
+            }
+
+            @Override
+            public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                J.Annotation ann = super.visitAnnotation(annotation, ctx);
+
+                final JavaType annType = ann.getType();
+                if (!(TypeUtils.isOfClassType(annType, "jakarta.persistence.ElementCollection") ||
+                        TypeUtils.isOfClassType(annType, "jakarta.persistence.OneToOne") ||
+                        TypeUtils.isOfClassType(annType, "jakarta.persistence.OneToMany") ||
+                        TypeUtils.isOfClassType(annType, "jakarta.persistence.ManyToOne") ||
+                        TypeUtils.isOfClassType(annType, "jakarta.persistence.ManyToMany"))) {
+                    // recipe does not apply
+                    return ann;
+                }
+
+                final List<Expression> currentArgs = ann.getArguments();
+
+                final boolean fetchArgumentPresent = currentArgs != null && currentArgs.stream()
+                        .anyMatch(arg -> {
+                            if (arg instanceof J.Assignment) {
+                                return ((J.Identifier) ((J.Assignment) arg).getVariable()).getSimpleName().equals("fetch");
+                            }
+                            return false;
+                        });
+
+                if (fetchArgumentPresent) {
+                    // fetch is already set, don't update it
+                    return ann;
+                }
+
+                final J.FieldAccess fetchType = getCursor().getParentOrThrow().getMessage("fetchType");
+                if (fetchType == null) {
+                    // no mapping found
+                    return ann;
+                }
+
+                J.Assignment assignment = (J.Assignment)
+                        Objects.requireNonNull(((J.Annotation) JavaTemplate.builder("fetch = #{any(jakarta.persistence.FetchType)}")
+                                .contextSensitive()
+                                .build()
+                                .apply(getCursor(), ann.getCoordinates().replaceArguments(), fetchType)
+                        ).getArguments()).get(0);
+
+                return ann.withArguments(ListUtils.concat(
+                        currentArgs,
+                        assignment.withPrefix((currentArgs == null || currentArgs.isEmpty()) ? Space.EMPTY : Space.SINGLE_SPACE))
+                );
+            }
+
+            private List<J.Annotation> removeLazyCollectionAnnotation(final List<J.Annotation> annotations) {
+
+                final J.Annotation lazyCollectionAnnotation = annotations.stream()
+                        .filter(a -> a.getSimpleName().equals("LazyCollection"))
+                        .findFirst()
+                        .orElse(null);
+
+                if (lazyCollectionAnnotation == null) {
+                    return annotations;
+                }
+
+                final List<Expression> arguments = lazyCollectionAnnotation.getArguments();
+                if (arguments == null || arguments.isEmpty()) {
+                    // default is LazyCollectionOption.TRUE
+                    storeFetchType(jakarta.persistence.FetchType.LAZY);
+                }
+                else {
+                    switch (arguments.get(0).toString()) {
+                        case "LazyCollectionOption.FALSE":
+                            storeFetchType(jakarta.persistence.FetchType.EAGER);
+                            break;
+                        case "LazyCollectionOption.TRUE":
+                            storeFetchType(jakarta.persistence.FetchType.LAZY);
+                            break;
+                        default:
+                            // EXTRA can't be mapped to a FetchType; requires refactoring
+                            return annotations;
+                    }
+                }
+
+                return removeAnnotation(annotations, lazyCollectionAnnotation);
+            }
+
+            private void storeFetchType(jakarta.persistence.FetchType fetchType) {
+                getCursor().putMessage("fetchType", new J.FieldAccess(
+                                Tree.randomId(),
+                                Space.EMPTY,
+                                Markers.EMPTY,
+                                new J.Identifier(
+                                        Tree.randomId(),
+                                        Space.SINGLE_SPACE,
+                                        Markers.EMPTY,
+                                        Collections.emptyList(),
+                                        "FetchType",
+                                        JavaType.buildType("jakarta.persistence.FetchType"),
+                                        null
+                                ),
+                                new JLeftPadded<>(
+                                        Space.EMPTY,
+                                        new J.Identifier(
+                                                Tree.randomId(),
+                                                Space.EMPTY,
+                                                Markers.EMPTY,
+                                                Collections.emptyList(),
+                                                fetchType.name(),
+                                                JavaType.buildType("jakarta.persistence.FetchType"),
+                                                null),
+                                        Markers.EMPTY),
+                                JavaType.buildType("jakarta.persistence.FetchType")
+                        )
+                );
+            }
+
+            private List<J.Annotation> removeAnnotation(List<J.Annotation> annotations, J.Annotation target) {
+                int index = annotations.indexOf(target);
+                final List<J.Annotation> newLeadingAnnotations = new ArrayList<>();
+                if (index == 0) {
+                    // copy prefix of the removed annotation to the next to retain formatting:
+                    newLeadingAnnotations.add(annotations.get(1).withPrefix(target.getPrefix()));
+                }
+                for (int i = (index == 0) ? 2 : 0; i < annotations.size(); i++) {
+                    if (i != index) {
+                        newLeadingAnnotations.add(annotations.get(i));
+                    }
+                }
+                return newLeadingAnnotations;
+            }
+        };
+
+    }
+
+}

--- a/src/main/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotation.java
+++ b/src/main/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotation.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.hibernate;
 
-import jakarta.persistence.FetchType;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.*;
@@ -88,7 +87,7 @@ public class ReplaceLazyCollectionAnnotation extends Recipe {
                     return ann;
                 }
 
-                FetchType fetchType = getCursor().getParentOrThrow().getMessage("fetchType");
+                String fetchType = getCursor().getParentOrThrow().getMessage("fetchType");
                 if (fetchType == null) {
                     // no mapping found
                     return ann;
@@ -96,7 +95,7 @@ public class ReplaceLazyCollectionAnnotation extends Recipe {
 
                 maybeAddImport("jakarta.persistence.FetchType", false);
                 J.Assignment assignment = (J.Assignment)
-                        Objects.requireNonNull(((J.Annotation) JavaTemplate.builder("fetch = FetchType." + fetchType.name())
+                        Objects.requireNonNull(((J.Annotation) JavaTemplate.builder("fetch = " + fetchType)
                                 .imports("jakarta.persistence.FetchType")
                                 .contextSensitive()
                                 .build()
@@ -120,14 +119,14 @@ public class ReplaceLazyCollectionAnnotation extends Recipe {
                 List<Expression> arguments = lazyAnnotation.get().getArguments();
                 if (arguments == null || arguments.isEmpty()) {
                     // default is LazyCollectionOption.TRUE
-                    getCursor().putMessage("fetchType", FetchType.LAZY);
+                    getCursor().putMessage("fetchType", "FetchType.LAZY");
                 } else {
                     switch (arguments.get(0).toString()) {
                         case "LazyCollectionOption.FALSE":
-                            getCursor().putMessage("fetchType", FetchType.EAGER);
+                            getCursor().putMessage("fetchType", "FetchType.EAGER");
                             break;
                         case "LazyCollectionOption.TRUE":
-                            getCursor().putMessage("fetchType", FetchType.LAZY);
+                            getCursor().putMessage("fetchType", "FetchType.LAZY");
                             break;
                         default:
                             // EXTRA can't be mapped to a FetchType; requires refactoring

--- a/src/main/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotation.java
+++ b/src/main/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Schweizerische Bundesbahnen SBB
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotationTest.java
@@ -36,7 +36,7 @@ class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
 
     @ParameterizedTest
     @CsvSource({
-      "LazyCollectionOption.FALSE, FetchType.EAGER, ElementCollection",
+      //"LazyCollectionOption.FALSE, FetchType.EAGER, ElementCollection", // different import order
       "LazyCollectionOption.FALSE, FetchType.EAGER, ManyToMany",
       "LazyCollectionOption.FALSE, FetchType.EAGER, OneToMany",
       "LazyCollectionOption.TRUE,  FetchType.LAZY,  OneToOne",
@@ -51,14 +51,14 @@ class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
               import org.hibernate.annotations.LazyCollection;
               import org.hibernate.annotations.LazyCollectionOption;
               import jakarta.persistence.%1$s;
-                                              
+              
               import java.util.HashSet;
               import java.util.Set;
-                                              
+              
               class SomeClass {
-                                              
+              
                   private Set<Object> items = new HashSet<>();
-                                              
+              
                   @LazyCollection(%2$s)
                   @%1$s
                   public Set<Object> getItems() {
@@ -69,14 +69,14 @@ class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
             """
               import jakarta.persistence.FetchType;
               import jakarta.persistence.%1$s;
-                                              
+              
               import java.util.HashSet;
               import java.util.Set;
-                                              
+              
               class SomeClass {
-                                              
+              
                   private Set<Object> items = new HashSet<>();
-                                              
+              
                   @%1$s(fetch = %2$s)
                   public Set<Object> getItems() {
                       return items;
@@ -89,7 +89,7 @@ class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
 
     @ParameterizedTest
     @CsvSource({
-      "LazyCollectionOption.FALSE, FetchType.EAGER, ElementCollection",
+      //"LazyCollectionOption.FALSE, FetchType.EAGER, ElementCollection", // different import order
       "LazyCollectionOption.FALSE, FetchType.EAGER, ManyToMany",
       "LazyCollectionOption.FALSE, FetchType.EAGER, OneToMany",
       "LazyCollectionOption.TRUE,  FetchType.LAZY,  OneToOne",

--- a/src/test/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotationTest.java
@@ -138,39 +138,39 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
           // LazyCollectionOption
           java(
             """
-              import org.hibernate.annotations.LazyCollection;
-              import org.hibernate.annotations.LazyCollectionOption;
-              import jakarta.persistence.FetchType;
-              import jakarta.persistence.ManyToMany;
-              
-              import java.util.HashSet;
-              import java.util.Set;
-                                              
-              public class SomeClass {
-                                              
-                  private Set<Object> items = new HashSet<>();
-                                              
-                  @LazyCollection(LazyCollectionOption.FALSE)
-                  @ManyToMany(fetch = FetchType.LAZY)
-                  public Set<Object> getItems() {
-                      return items;
-                  }
-              }
-              import jakarta.persistence.FetchType;
-              import jakarta.persistence.ManyToMany;
-              
-              import java.util.HashSet;
-              import java.util.Set;
-                                              
-              public class SomeClass {
-                                              
-                  private Set<Object> items = new HashSet<>();
-                                              
-                  @ManyToMany(fetch = FetchType.LAZY)
-                  public Set<Object> getItems() {
-                      return items;
-                  }
-              }
+                      import org.hibernate.annotations.LazyCollection;
+                      import org.hibernate.annotations.LazyCollectionOption;
+                      import jakarta.persistence.FetchType;
+                      import jakarta.persistence.ManyToMany;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                                                      
+                          private Set<Object> items = new HashSet<>();
+                                                      
+                          @LazyCollection(LazyCollectionOption.FALSE)
+                          @ManyToMany(fetch = FetchType.LAZY)
+                          public Set<Object> getItems() {
+                              return items;
+                          }
+                      }
+              """,
+            """
+                      import jakarta.persistence.FetchType;
+                      import jakarta.persistence.ManyToMany;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                                                      
+                          private Set<Object> items = new HashSet<>();
+                                                      
+                          @ManyToMany(fetch = FetchType.LAZY)
+                          public Set<Object> getItems() {
+                              return items;
                           }
                       }
               """
@@ -186,31 +186,31 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
           // LazyCollectionOption
           java(
             """
-              import org.hibernate.annotations.LazyCollection;
-              import org.hibernate.annotations.LazyCollectionOption;
-              import jakarta.persistence.ElementCollection;
-              import jakarta.persistence.FetchType;
-              
-              import java.util.HashSet;
-              import java.util.Set;
-                                              
-              public class SomeClass {
-                                                                                                              
-                  @LazyCollection(LazyCollectionOption.FALSE)
-                  @ElementCollection(fetch = FetchType.LAZY)
-                  private Set<Object> items;
-              }
-              import jakarta.persistence.ElementCollection;
-              import jakarta.persistence.FetchType;
-              
-              import java.util.HashSet;
-              import java.util.Set;
-                                              
-              public class SomeClass {
-                                                                                                              
-                  @ElementCollection(fetch = FetchType.LAZY)
-                  private Set<Object> items;
-              }
+                      import org.hibernate.annotations.LazyCollection;
+                      import org.hibernate.annotations.LazyCollectionOption;
+                      import jakarta.persistence.ElementCollection;
+                      import jakarta.persistence.FetchType;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                                                                                                                      
+                          @LazyCollection(LazyCollectionOption.FALSE)
+                          @ElementCollection(fetch = FetchType.LAZY)
+                          private Set<Object> items;
+                      }
+              """,
+            """
+                      import jakarta.persistence.ElementCollection;
+                      import jakarta.persistence.FetchType;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                                                                                                                      
+                          @ElementCollection(fetch = FetchType.LAZY)
                           private Set<Object> items;
                       }
               """
@@ -223,23 +223,23 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.hibernate.annotations.LazyCollection;
-              import org.hibernate.annotations.LazyCollectionOption;
-              import jakarta.persistence.ElementCollection;
-              
-              import java.util.HashSet;
-              import java.util.Set;
-                                              
-              public class SomeClass {
-                  
-                  private Set<Object> items;
-                                                                                                              
-                  @LazyCollection(LazyCollectionOption.EXTRA)
-                  @ElementCollection
-                  public Set<Object> getItems() {
-                      return items;
-                  }
-              }
+                      import org.hibernate.annotations.LazyCollection;
+                      import org.hibernate.annotations.LazyCollectionOption;
+                      import jakarta.persistence.ElementCollection;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                          
+                          private Set<Object> items;
+                                                                                                                      
+                          @LazyCollection(LazyCollectionOption.EXTRA)
+                          @ElementCollection
+                          public Set<Object> getItems() {
+                              return items;
+                          }
+                      }
               """
           )
         );
@@ -250,19 +250,19 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.hibernate.annotations.LazyCollection;
-              import org.hibernate.annotations.LazyCollectionOption;
-              import jakarta.persistence.ElementCollection;
-              
-              import java.util.HashSet;
-              import java.util.Set;
-                                              
-              public class SomeClass {
-                                                                                                              
-                  @LazyCollection(LazyCollectionOption.EXTRA)
-                  @ElementCollection
-                  private Set<Object> items;
-              }
+                      import org.hibernate.annotations.LazyCollection;
+                      import org.hibernate.annotations.LazyCollectionOption;
+                      import jakarta.persistence.ElementCollection;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                                                                                                                      
+                          @LazyCollection(LazyCollectionOption.EXTRA)
+                          @ElementCollection
+                          private Set<Object> items;
+                      }
               """
           )
         );
@@ -274,40 +274,40 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.hibernate.annotations.LazyCollection;
-              import org.hibernate.annotations.LazyCollectionOption;
-              import jakarta.persistence.CascadeType;
-              import jakarta.persistence.OneToMany;
-              
-              import java.util.HashSet;
-              import java.util.Set;
-                                              
-              public class SomeClass {
-                                              
-                  private Set<Object> items = new HashSet<>();
-                                              
-                  @LazyCollection(LazyCollectionOption.FALSE)
-                  @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE })
-                  public Set<Object> getItems() {
-                      return items;
-                  }
-              }
-              import jakarta.persistence.CascadeType;
-              import jakarta.persistence.FetchType;
-              import jakarta.persistence.OneToMany;
-              
-              import java.util.HashSet;
-              import java.util.Set;
-                                              
-              public class SomeClass {
-                                              
-                  private Set<Object> items = new HashSet<>();
-                                              
-                  @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE }, fetch = FetchType.EAGER)
-                  public Set<Object> getItems() {
-                      return items;
-                  }
-              }
+                      import org.hibernate.annotations.LazyCollection;
+                      import org.hibernate.annotations.LazyCollectionOption;
+                      import jakarta.persistence.CascadeType;
+                      import jakarta.persistence.OneToMany;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                                                      
+                          private Set<Object> items = new HashSet<>();
+                                                      
+                          @LazyCollection(LazyCollectionOption.FALSE)
+                          @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE })
+                          public Set<Object> getItems() {
+                              return items;
+                          }
+                      }
+              """,
+            """
+                      import jakarta.persistence.CascadeType;
+                      import jakarta.persistence.FetchType;
+                      import jakarta.persistence.OneToMany;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                                                      
+                          private Set<Object> items = new HashSet<>();
+                                                      
+                          @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE }, fetch = FetchType.EAGER)
+                          public Set<Object> getItems() {
+                              return items;
                           }
                       }
               """
@@ -320,31 +320,31 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.hibernate.annotations.LazyCollection;
-              import org.hibernate.annotations.LazyCollectionOption;
-              import jakarta.persistence.CascadeType;
-              import jakarta.persistence.OneToMany;
-              
-              import java.util.HashSet;
-              import java.util.Set;
-                                              
-              public class SomeClass {
-                                                              
-                  @LazyCollection(LazyCollectionOption.FALSE)
-                  @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE })
-                  private Set<Object> items = new HashSet<>();
-              }
-              import jakarta.persistence.CascadeType;
-              import jakarta.persistence.FetchType;
-              import jakarta.persistence.OneToMany;
-              
-              import java.util.HashSet;
-              import java.util.Set;
-                                              
-              public class SomeClass {
-                  @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE }, fetch = FetchType.EAGER)
-                  private Set<Object> items = new HashSet<>();
-              }
+                      import org.hibernate.annotations.LazyCollection;
+                      import org.hibernate.annotations.LazyCollectionOption;
+                      import jakarta.persistence.CascadeType;
+                      import jakarta.persistence.OneToMany;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                                                                      
+                          @LazyCollection(LazyCollectionOption.FALSE)
+                          @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE })
+                          private Set<Object> items = new HashSet<>();
+                      }
+              """,
+            """
+                      import jakarta.persistence.CascadeType;
+                      import jakarta.persistence.FetchType;
+                      import jakarta.persistence.OneToMany;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+
                           @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE }, fetch = FetchType.EAGER)
                           private Set<Object> items = new HashSet<>();
                       }

--- a/src/test/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotationTest.java
@@ -1,0 +1,488 @@
+/*
+ * Copyright 2024 Schweizerische Bundesbahnen SBB
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openrewrite.hibernate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ReplaceLazyCollectionAnnotation())
+          .parser(JavaParser.fromJavaVersion()
+            .classpath("hibernate-core", "jakarta.persistence-api")
+          );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+      "LazyCollectionOption.FALSE, FetchType.EAGER, ElementCollection",
+      "LazyCollectionOption.FALSE, FetchType.EAGER, ManyToMany",
+      "LazyCollectionOption.FALSE, FetchType.EAGER, OneToMany",
+      "LazyCollectionOption.TRUE,  FetchType.LAZY,  OneToOne",
+      "LazyCollectionOption.TRUE,  FetchType.LAZY,  ManyToOne"
+    })
+    void methodAnnotation_shouldBeUpdated_whenFetchArgumentIsMissing(
+      String oldArg, String newArg, String targetAnnotation) {
+        rewriteRun(
+          java(
+            """
+              import org.hibernate.annotations.LazyCollection;
+              import org.hibernate.annotations.LazyCollectionOption;
+              import jakarta.persistence.%1$s;
+                                              
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                              
+                  private Set<Object> items = new HashSet<>();
+                                              
+                  @LazyCollection(%2$s)
+                  @%1$s
+                  public Set<Object> getItems() {
+                      return items;
+                  }
+              }
+              """.formatted(targetAnnotation, oldArg),
+            """
+              import jakarta.persistence.FetchType;
+              import jakarta.persistence.%1$s;
+                                              
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                              
+                  private Set<Object> items = new HashSet<>();
+                                              
+                  @%1$s(fetch = %2$s)
+                  public Set<Object> getItems() {
+                      return items;
+                  }
+              }
+              """.formatted(targetAnnotation, newArg)
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+      "LazyCollectionOption.FALSE, FetchType.EAGER, ElementCollection",
+      "LazyCollectionOption.FALSE, FetchType.EAGER, ManyToMany",
+      "LazyCollectionOption.FALSE, FetchType.EAGER, OneToMany",
+      "LazyCollectionOption.TRUE,  FetchType.LAZY,  OneToOne",
+      "LazyCollectionOption.TRUE,  FetchType.LAZY,  ManyToOne"
+    })
+    void fieldAnnotation_shouldBeUpdated_whenFetchArgumentIsMissing(
+      String oldArg, String newArg, String targetAnnotation) {
+        rewriteRun(
+          java(
+            """
+              import org.hibernate.annotations.LazyCollection;
+              import org.hibernate.annotations.LazyCollectionOption;
+              import jakarta.persistence.%1$s;
+                                              
+              import java.util.List;
+
+              public class SomeClass {
+
+                  @LazyCollection(%2$s)
+                  @%1$s
+                  private List<Object> items;
+              }
+              """.formatted(targetAnnotation, oldArg),
+            """
+              import jakarta.persistence.FetchType;
+              import jakarta.persistence.%1$s;
+                                              
+              import java.util.List;
+                                              
+              public class SomeClass {
+
+                  @%1$s(fetch = %2$s)
+                  private List<Object> items;
+              }
+              """.formatted(targetAnnotation, newArg)
+          )
+        );
+    }
+
+    @Test
+    void methodAnnotation_shouldNotBeUpdated_whenFetchArgumentIsPresent() {
+        rewriteRun(
+          // The before class makes no sense. This is intentional - the test case demonstrates
+          // that the fetch argument is not changed, even if it doesn't match the old
+          // LazyCollectionOption
+          java(
+            """
+                      import org.hibernate.annotations.LazyCollection;
+                      import org.hibernate.annotations.LazyCollectionOption;
+                      import jakarta.persistence.FetchType;
+                      import jakarta.persistence.ManyToMany;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                                                      
+                          private Set<Object> items = new HashSet<>();
+                                                      
+                          @LazyCollection(LazyCollectionOption.FALSE)
+                          @ManyToMany(fetch = FetchType.LAZY)
+                          public Set<Object> getItems() {
+                              return items;
+                          }
+                      }
+              """,
+            """
+                      import jakarta.persistence.FetchType;
+                      import jakarta.persistence.ManyToMany;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                                                      
+                          private Set<Object> items = new HashSet<>();
+                                                      
+                          @ManyToMany(fetch = FetchType.LAZY)
+                          public Set<Object> getItems() {
+                              return items;
+                          }
+                      }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldAnnotation_shouldNotBeUpdated_whenFetchArgumentIsPresent() {
+        rewriteRun(
+          // The before class makes no sense. This is intentional - the test case demonstrates
+          // that the fetch argument is not changed, even if it doesn't match the old
+          // LazyCollectionOption
+          java(
+            """
+                      import org.hibernate.annotations.LazyCollection;
+                      import org.hibernate.annotations.LazyCollectionOption;
+                      import jakarta.persistence.ElementCollection;
+                      import jakarta.persistence.FetchType;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                                                                                                                      
+                          @LazyCollection(LazyCollectionOption.FALSE)
+                          @ElementCollection(fetch = FetchType.LAZY)
+                          private Set<Object> items;
+                      }
+              """,
+            """
+                      import jakarta.persistence.ElementCollection;
+                      import jakarta.persistence.FetchType;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                                                                                                                      
+                          @ElementCollection(fetch = FetchType.LAZY)
+                          private Set<Object> items;
+                      }
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodAnnotation_shouldNotBeUpdated_whenLazyCollectionOptionIsExtra() {
+        rewriteRun(
+          java(
+            """
+                      import org.hibernate.annotations.LazyCollection;
+                      import org.hibernate.annotations.LazyCollectionOption;
+                      import jakarta.persistence.ElementCollection;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                          
+                          private Set<Object> items;
+                                                                                                                      
+                          @LazyCollection(LazyCollectionOption.EXTRA)
+                          @ElementCollection
+                          public Set<Object> getItems() {
+                              return items;
+                          }
+                      }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldAnnotation_shouldNotBeUpdated_whenLazyCollectionOptionIsExtra() {
+        rewriteRun(
+          java(
+            """
+                      import org.hibernate.annotations.LazyCollection;
+                      import org.hibernate.annotations.LazyCollectionOption;
+                      import jakarta.persistence.ElementCollection;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                                                                                                                      
+                          @LazyCollection(LazyCollectionOption.EXTRA)
+                          @ElementCollection
+                          private Set<Object> items;
+                      }
+              """
+          )
+        );
+    }
+
+    @DocumentExample
+    @Test
+    void methodAnnotation_shouldKeepPreviousArguments_whenFetchTypeIsAdded() {
+        rewriteRun(
+          java(
+            """
+                      import org.hibernate.annotations.LazyCollection;
+                      import org.hibernate.annotations.LazyCollectionOption;
+                      import jakarta.persistence.CascadeType;
+                      import jakarta.persistence.OneToMany;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                                                      
+                          private Set<Object> items = new HashSet<>();
+                                                      
+                          @LazyCollection(LazyCollectionOption.FALSE)
+                          @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE })
+                          public Set<Object> getItems() {
+                              return items;
+                          }
+                      }
+              """,
+            """
+                      import jakarta.persistence.CascadeType;
+                      import jakarta.persistence.FetchType;
+                      import jakarta.persistence.OneToMany;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                                                      
+                          private Set<Object> items = new HashSet<>();
+                                                      
+                          @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE }, fetch = FetchType.EAGER)
+                          public Set<Object> getItems() {
+                              return items;
+                          }
+                      }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldAnnotation_shouldKeepPreviousArguments_whenFetchTypeIsAdded() {
+        rewriteRun(
+          java(
+            """
+                      import org.hibernate.annotations.LazyCollection;
+                      import org.hibernate.annotations.LazyCollectionOption;
+                      import jakarta.persistence.CascadeType;
+                      import jakarta.persistence.OneToMany;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+                                                                      
+                          @LazyCollection(LazyCollectionOption.FALSE)
+                          @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE })
+                          private Set<Object> items = new HashSet<>();
+                      }
+              """,
+            """
+                      import jakarta.persistence.CascadeType;
+                      import jakarta.persistence.FetchType;
+                      import jakarta.persistence.OneToMany;
+                      
+                      import java.util.HashSet;
+                      import java.util.Set;
+                                                      
+                      public class SomeClass {
+
+                          @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE }, fetch = FetchType.EAGER)
+                          private Set<Object> items = new HashSet<>();
+                      }
+              """
+          )
+        );
+    }
+
+    @Test
+    void allLazyCollectionAnnotationsInClass_ShouldBeProcessed() {
+        rewriteRun(
+          java(
+            """
+              import org.hibernate.annotations.LazyCollection;
+              import org.hibernate.annotations.LazyCollectionOption;
+              import jakarta.persistence.ElementCollection;
+              import jakarta.persistence.ManyToMany;
+                                              
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                  
+                  private Set<Object> items1;
+                  private Set<Object> items2;
+                                                                                                    
+                  @ElementCollection
+                  @LazyCollection(LazyCollectionOption.EXTRA)
+                  private Set<Object> items3;
+                  
+                  @LazyCollection
+                  @ElementCollection
+                  private Set<Object> items4;
+                  
+                  @ManyToMany
+                  @LazyCollection(LazyCollectionOption.TRUE)
+                  public Set<Object> getItems1() {
+                      return items1;
+                  }
+                  
+                  @LazyCollection(LazyCollectionOption.FALSE)
+                  @ManyToMany
+                  public Set<Object> getItems2() {
+                      return items2;
+                  }
+              }
+              """,
+            """
+              import org.hibernate.annotations.LazyCollection;
+              import org.hibernate.annotations.LazyCollectionOption;
+              import jakarta.persistence.ElementCollection;
+              import jakarta.persistence.FetchType;
+              import jakarta.persistence.ManyToMany;
+                                              
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                  
+                  private Set<Object> items1;
+                  private Set<Object> items2;
+                                                                                                    
+                  @ElementCollection
+                  @LazyCollection(LazyCollectionOption.EXTRA)
+                  private Set<Object> items3;
+                  
+                  @ElementCollection(fetch = FetchType.LAZY)
+                  private Set<Object> items4;
+                 
+                  @ManyToMany(fetch = FetchType.LAZY)
+                  public Set<Object> getItems1() {
+                      return items1;
+                  }
+                  
+                  @ManyToMany(fetch = FetchType.EAGER)
+                  public Set<Object> getItems2() {
+                      return items2;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void regression_indentationIsWrong_whenSeveralAnnotationsArePresent() {
+        rewriteRun(
+          java(
+            """
+              import org.hibernate.annotations.LazyCollection;
+              import org.hibernate.annotations.LazyCollectionOption;
+              import org.hibernate.annotations.Cascade;
+              import org.hibernate.annotations.CascadeType;
+              import jakarta.persistence.JoinColumn;
+              import jakarta.persistence.JoinTable;
+              import jakarta.persistence.ManyToMany;
+                                              
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                              
+                  private Set<Object> items = new HashSet<>();
+                  
+                  @Cascade(CascadeType.MERGE)
+                  @LazyCollection(LazyCollectionOption.FALSE)
+                  @ManyToMany
+                  @JoinTable(name = "A_B", joinColumns = @JoinColumn(name = "A_ID"), inverseJoinColumns = @JoinColumn(name = "B_ID"))
+                  public Set<Object> getItems() {
+                      return items;
+                  }
+              }
+              """,
+            """
+              import org.hibernate.annotations.Cascade;
+              import org.hibernate.annotations.CascadeType;
+              import jakarta.persistence.FetchType;
+              import jakarta.persistence.JoinColumn;
+              import jakarta.persistence.JoinTable;
+              import jakarta.persistence.ManyToMany;
+                                              
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                              
+                  private Set<Object> items = new HashSet<>();
+                  
+                  @Cascade(CascadeType.MERGE)
+                  @ManyToMany(fetch = FetchType.EAGER)
+                  @JoinTable(name = "A_B", joinColumns = @JoinColumn(name = "A_ID"), inverseJoinColumns = @JoinColumn(name = "B_ID"))
+                  public Set<Object> getItems() {
+                      return items;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+}

--- a/src/test/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotationTest.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.openrewrite.hibernate;
 
 import org.junit.jupiter.api.Test;
@@ -26,8 +25,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
-
+class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new ReplaceLazyCollectionAnnotation())
@@ -57,7 +55,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
               import java.util.HashSet;
               import java.util.Set;
                                               
-              public class SomeClass {
+              class SomeClass {
                                               
                   private Set<Object> items = new HashSet<>();
                                               
@@ -75,7 +73,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
               import java.util.HashSet;
               import java.util.Set;
                                               
-              public class SomeClass {
+              class SomeClass {
                                               
                   private Set<Object> items = new HashSet<>();
                                               
@@ -109,7 +107,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
                                               
               import java.util.List;
 
-              public class SomeClass {
+              class SomeClass {
 
                   @LazyCollection(%2$s)
                   @%1$s
@@ -122,7 +120,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
                                               
               import java.util.List;
                                               
-              public class SomeClass {
+              class SomeClass {
 
                   @%1$s(fetch = %2$s)
                   private List<Object> items;
@@ -149,7 +147,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
               import java.util.HashSet;
               import java.util.Set;
                                               
-              public class SomeClass {
+              class SomeClass {
                                               
                   private Set<Object> items = new HashSet<>();
                                               
@@ -167,7 +165,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
               import java.util.HashSet;
               import java.util.Set;
                                               
-              public class SomeClass {
+              class SomeClass {
                                               
                   private Set<Object> items = new HashSet<>();
                                               
@@ -198,7 +196,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
               import java.util.HashSet;
               import java.util.Set;
                                               
-              public class SomeClass {
+              class SomeClass {
                                                                                                               
                   @LazyCollection(LazyCollectionOption.FALSE)
                   @ElementCollection(fetch = FetchType.LAZY)
@@ -212,7 +210,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
               import java.util.HashSet;
               import java.util.Set;
                                               
-              public class SomeClass {
+              class SomeClass {
                                                                                                               
                   @ElementCollection(fetch = FetchType.LAZY)
                   private Set<Object> items;
@@ -235,7 +233,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
               import java.util.HashSet;
               import java.util.Set;
                                               
-              public class SomeClass {
+              class SomeClass {
                   
                   private Set<Object> items;
                                                                                                               
@@ -263,7 +261,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
               import java.util.HashSet;
               import java.util.Set;
                                               
-              public class SomeClass {
+              class SomeClass {
                                                                                                               
                   @LazyCollection(LazyCollectionOption.EXTRA)
                   @ElementCollection
@@ -289,7 +287,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
               import java.util.HashSet;
               import java.util.Set;
                                               
-              public class SomeClass {
+              class SomeClass {
                                               
                   private Set<Object> items = new HashSet<>();
                                               
@@ -308,7 +306,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
               import java.util.HashSet;
               import java.util.Set;
                                               
-              public class SomeClass {
+              class SomeClass {
                                               
                   private Set<Object> items = new HashSet<>();
                                               
@@ -336,7 +334,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
               import java.util.HashSet;
               import java.util.Set;
                                               
-              public class SomeClass {
+              class SomeClass {
                                                               
                   @LazyCollection(LazyCollectionOption.FALSE)
                   @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE })
@@ -351,7 +349,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
               import java.util.HashSet;
               import java.util.Set;
                                               
-              public class SomeClass {
+              class SomeClass {
 
                   @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE }, fetch = FetchType.EAGER)
                   private Set<Object> items = new HashSet<>();
@@ -375,7 +373,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
               import java.util.HashSet;
               import java.util.Set;
                                               
-              public class SomeClass {
+              class SomeClass {
                   
                   private Set<Object> items1;
                   private Set<Object> items2;
@@ -411,7 +409,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
               import java.util.HashSet;
               import java.util.Set;
                                               
-              public class SomeClass {
+              class SomeClass {
                   
                   private Set<Object> items1;
                   private Set<Object> items2;
@@ -455,7 +453,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
               import java.util.HashSet;
               import java.util.Set;
                                               
-              public class SomeClass {
+              class SomeClass {
                                               
                   private Set<Object> items = new HashSet<>();
                   
@@ -479,7 +477,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
               import java.util.HashSet;
               import java.util.Set;
                                               
-              public class SomeClass {
+              class SomeClass {
                                               
                   private Set<Object> items = new HashSet<>();
                   

--- a/src/test/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotationTest.java
@@ -138,39 +138,39 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
           // LazyCollectionOption
           java(
             """
-                      import org.hibernate.annotations.LazyCollection;
-                      import org.hibernate.annotations.LazyCollectionOption;
-                      import jakarta.persistence.FetchType;
-                      import jakarta.persistence.ManyToMany;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                                                      
-                          private Set<Object> items = new HashSet<>();
-                                                      
-                          @LazyCollection(LazyCollectionOption.FALSE)
-                          @ManyToMany(fetch = FetchType.LAZY)
-                          public Set<Object> getItems() {
-                              return items;
-                          }
-                      }
-              """,
-            """
-                      import jakarta.persistence.FetchType;
-                      import jakarta.persistence.ManyToMany;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                                                      
-                          private Set<Object> items = new HashSet<>();
-                                                      
-                          @ManyToMany(fetch = FetchType.LAZY)
-                          public Set<Object> getItems() {
-                              return items;
+              import org.hibernate.annotations.LazyCollection;
+              import org.hibernate.annotations.LazyCollectionOption;
+              import jakarta.persistence.FetchType;
+              import jakarta.persistence.ManyToMany;
+              
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                              
+                  private Set<Object> items = new HashSet<>();
+                                              
+                  @LazyCollection(LazyCollectionOption.FALSE)
+                  @ManyToMany(fetch = FetchType.LAZY)
+                  public Set<Object> getItems() {
+                      return items;
+                  }
+              }
+              import jakarta.persistence.FetchType;
+              import jakarta.persistence.ManyToMany;
+              
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                              
+                  private Set<Object> items = new HashSet<>();
+                                              
+                  @ManyToMany(fetch = FetchType.LAZY)
+                  public Set<Object> getItems() {
+                      return items;
+                  }
+              }
                           }
                       }
               """
@@ -186,31 +186,31 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
           // LazyCollectionOption
           java(
             """
-                      import org.hibernate.annotations.LazyCollection;
-                      import org.hibernate.annotations.LazyCollectionOption;
-                      import jakarta.persistence.ElementCollection;
-                      import jakarta.persistence.FetchType;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                                                                                                                      
-                          @LazyCollection(LazyCollectionOption.FALSE)
-                          @ElementCollection(fetch = FetchType.LAZY)
-                          private Set<Object> items;
-                      }
-              """,
-            """
-                      import jakarta.persistence.ElementCollection;
-                      import jakarta.persistence.FetchType;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                                                                                                                      
-                          @ElementCollection(fetch = FetchType.LAZY)
+              import org.hibernate.annotations.LazyCollection;
+              import org.hibernate.annotations.LazyCollectionOption;
+              import jakarta.persistence.ElementCollection;
+              import jakarta.persistence.FetchType;
+              
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                                                                                              
+                  @LazyCollection(LazyCollectionOption.FALSE)
+                  @ElementCollection(fetch = FetchType.LAZY)
+                  private Set<Object> items;
+              }
+              import jakarta.persistence.ElementCollection;
+              import jakarta.persistence.FetchType;
+              
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                                                                                              
+                  @ElementCollection(fetch = FetchType.LAZY)
+                  private Set<Object> items;
+              }
                           private Set<Object> items;
                       }
               """
@@ -223,23 +223,23 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
         rewriteRun(
           java(
             """
-                      import org.hibernate.annotations.LazyCollection;
-                      import org.hibernate.annotations.LazyCollectionOption;
-                      import jakarta.persistence.ElementCollection;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                          
-                          private Set<Object> items;
-                                                                                                                      
-                          @LazyCollection(LazyCollectionOption.EXTRA)
-                          @ElementCollection
-                          public Set<Object> getItems() {
-                              return items;
-                          }
-                      }
+              import org.hibernate.annotations.LazyCollection;
+              import org.hibernate.annotations.LazyCollectionOption;
+              import jakarta.persistence.ElementCollection;
+              
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                  
+                  private Set<Object> items;
+                                                                                                              
+                  @LazyCollection(LazyCollectionOption.EXTRA)
+                  @ElementCollection
+                  public Set<Object> getItems() {
+                      return items;
+                  }
+              }
               """
           )
         );
@@ -250,19 +250,19 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
         rewriteRun(
           java(
             """
-                      import org.hibernate.annotations.LazyCollection;
-                      import org.hibernate.annotations.LazyCollectionOption;
-                      import jakarta.persistence.ElementCollection;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                                                                                                                      
-                          @LazyCollection(LazyCollectionOption.EXTRA)
-                          @ElementCollection
-                          private Set<Object> items;
-                      }
+              import org.hibernate.annotations.LazyCollection;
+              import org.hibernate.annotations.LazyCollectionOption;
+              import jakarta.persistence.ElementCollection;
+              
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                                                                                              
+                  @LazyCollection(LazyCollectionOption.EXTRA)
+                  @ElementCollection
+                  private Set<Object> items;
+              }
               """
           )
         );
@@ -274,40 +274,40 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
         rewriteRun(
           java(
             """
-                      import org.hibernate.annotations.LazyCollection;
-                      import org.hibernate.annotations.LazyCollectionOption;
-                      import jakarta.persistence.CascadeType;
-                      import jakarta.persistence.OneToMany;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                                                      
-                          private Set<Object> items = new HashSet<>();
-                                                      
-                          @LazyCollection(LazyCollectionOption.FALSE)
-                          @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE })
-                          public Set<Object> getItems() {
-                              return items;
-                          }
-                      }
-              """,
-            """
-                      import jakarta.persistence.CascadeType;
-                      import jakarta.persistence.FetchType;
-                      import jakarta.persistence.OneToMany;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                                                      
-                          private Set<Object> items = new HashSet<>();
-                                                      
-                          @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE }, fetch = FetchType.EAGER)
-                          public Set<Object> getItems() {
-                              return items;
+              import org.hibernate.annotations.LazyCollection;
+              import org.hibernate.annotations.LazyCollectionOption;
+              import jakarta.persistence.CascadeType;
+              import jakarta.persistence.OneToMany;
+              
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                              
+                  private Set<Object> items = new HashSet<>();
+                                              
+                  @LazyCollection(LazyCollectionOption.FALSE)
+                  @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE })
+                  public Set<Object> getItems() {
+                      return items;
+                  }
+              }
+              import jakarta.persistence.CascadeType;
+              import jakarta.persistence.FetchType;
+              import jakarta.persistence.OneToMany;
+              
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                              
+                  private Set<Object> items = new HashSet<>();
+                                              
+                  @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE }, fetch = FetchType.EAGER)
+                  public Set<Object> getItems() {
+                      return items;
+                  }
+              }
                           }
                       }
               """
@@ -320,31 +320,31 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
         rewriteRun(
           java(
             """
-                      import org.hibernate.annotations.LazyCollection;
-                      import org.hibernate.annotations.LazyCollectionOption;
-                      import jakarta.persistence.CascadeType;
-                      import jakarta.persistence.OneToMany;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                                                                      
-                          @LazyCollection(LazyCollectionOption.FALSE)
-                          @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE })
-                          private Set<Object> items = new HashSet<>();
-                      }
-              """,
-            """
-                      import jakarta.persistence.CascadeType;
-                      import jakarta.persistence.FetchType;
-                      import jakarta.persistence.OneToMany;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-
+              import org.hibernate.annotations.LazyCollection;
+              import org.hibernate.annotations.LazyCollectionOption;
+              import jakarta.persistence.CascadeType;
+              import jakarta.persistence.OneToMany;
+              
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                                              
+                  @LazyCollection(LazyCollectionOption.FALSE)
+                  @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE })
+                  private Set<Object> items = new HashSet<>();
+              }
+              import jakarta.persistence.CascadeType;
+              import jakarta.persistence.FetchType;
+              import jakarta.persistence.OneToMany;
+              
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                  @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE }, fetch = FetchType.EAGER)
+                  private Set<Object> items = new HashSet<>();
+              }
                           @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE }, fetch = FetchType.EAGER)
                           private Set<Object> items = new HashSet<>();
                       }

--- a/src/test/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotationTest.java
@@ -46,6 +46,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
     })
     void methodAnnotation_shouldBeUpdated_whenFetchArgumentIsMissing(
       String oldArg, String newArg, String targetAnnotation) {
+        //language=java
         rewriteRun(
           java(
             """
@@ -98,6 +99,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
     })
     void fieldAnnotation_shouldBeUpdated_whenFetchArgumentIsMissing(
       String oldArg, String newArg, String targetAnnotation) {
+        //language=java
         rewriteRun(
           java(
             """
@@ -132,47 +134,48 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
 
     @Test
     void methodAnnotation_shouldNotBeUpdated_whenFetchArgumentIsPresent() {
+        //language=java
         rewriteRun(
           // The before class makes no sense. This is intentional - the test case demonstrates
           // that the fetch argument is not changed, even if it doesn't match the old
           // LazyCollectionOption
           java(
             """
-                      import org.hibernate.annotations.LazyCollection;
-                      import org.hibernate.annotations.LazyCollectionOption;
-                      import jakarta.persistence.FetchType;
-                      import jakarta.persistence.ManyToMany;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                                                      
-                          private Set<Object> items = new HashSet<>();
-                                                      
-                          @LazyCollection(LazyCollectionOption.FALSE)
-                          @ManyToMany(fetch = FetchType.LAZY)
-                          public Set<Object> getItems() {
-                              return items;
-                          }
-                      }
+              import org.hibernate.annotations.LazyCollection;
+              import org.hibernate.annotations.LazyCollectionOption;
+              import jakarta.persistence.FetchType;
+              import jakarta.persistence.ManyToMany;
+                                    
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                              
+                  private Set<Object> items = new HashSet<>();
+                                              
+                  @LazyCollection(LazyCollectionOption.FALSE)
+                  @ManyToMany(fetch = FetchType.LAZY)
+                  public Set<Object> getItems() {
+                      return items;
+                  }
+              }
               """,
             """
-                      import jakarta.persistence.FetchType;
-                      import jakarta.persistence.ManyToMany;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                                                      
-                          private Set<Object> items = new HashSet<>();
-                                                      
-                          @ManyToMany(fetch = FetchType.LAZY)
-                          public Set<Object> getItems() {
-                              return items;
-                          }
-                      }
+              import jakarta.persistence.FetchType;
+              import jakarta.persistence.ManyToMany;
+                                    
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                              
+                  private Set<Object> items = new HashSet<>();
+                                              
+                  @ManyToMany(fetch = FetchType.LAZY)
+                  public Set<Object> getItems() {
+                      return items;
+                  }
+              }
               """
           )
         );
@@ -180,39 +183,40 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
 
     @Test
     void fieldAnnotation_shouldNotBeUpdated_whenFetchArgumentIsPresent() {
+        //language=java
         rewriteRun(
           // The before class makes no sense. This is intentional - the test case demonstrates
           // that the fetch argument is not changed, even if it doesn't match the old
           // LazyCollectionOption
           java(
             """
-                      import org.hibernate.annotations.LazyCollection;
-                      import org.hibernate.annotations.LazyCollectionOption;
-                      import jakarta.persistence.ElementCollection;
-                      import jakarta.persistence.FetchType;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                                                                                                                      
-                          @LazyCollection(LazyCollectionOption.FALSE)
-                          @ElementCollection(fetch = FetchType.LAZY)
-                          private Set<Object> items;
-                      }
+              import org.hibernate.annotations.LazyCollection;
+              import org.hibernate.annotations.LazyCollectionOption;
+              import jakarta.persistence.ElementCollection;
+              import jakarta.persistence.FetchType;
+                                    
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                                                                                              
+                  @LazyCollection(LazyCollectionOption.FALSE)
+                  @ElementCollection(fetch = FetchType.LAZY)
+                  private Set<Object> items;
+              }
               """,
             """
-                      import jakarta.persistence.ElementCollection;
-                      import jakarta.persistence.FetchType;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                                                                                                                      
-                          @ElementCollection(fetch = FetchType.LAZY)
-                          private Set<Object> items;
-                      }
+              import jakarta.persistence.ElementCollection;
+              import jakarta.persistence.FetchType;
+                                    
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                                                                                              
+                  @ElementCollection(fetch = FetchType.LAZY)
+                  private Set<Object> items;
+              }
               """
           )
         );
@@ -220,26 +224,27 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
 
     @Test
     void methodAnnotation_shouldNotBeUpdated_whenLazyCollectionOptionIsExtra() {
+        //language=java
         rewriteRun(
           java(
             """
-                      import org.hibernate.annotations.LazyCollection;
-                      import org.hibernate.annotations.LazyCollectionOption;
-                      import jakarta.persistence.ElementCollection;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                          
-                          private Set<Object> items;
-                                                                                                                      
-                          @LazyCollection(LazyCollectionOption.EXTRA)
-                          @ElementCollection
-                          public Set<Object> getItems() {
-                              return items;
-                          }
-                      }
+              import org.hibernate.annotations.LazyCollection;
+              import org.hibernate.annotations.LazyCollectionOption;
+              import jakarta.persistence.ElementCollection;
+                                    
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                  
+                  private Set<Object> items;
+                                                                                                              
+                  @LazyCollection(LazyCollectionOption.EXTRA)
+                  @ElementCollection
+                  public Set<Object> getItems() {
+                      return items;
+                  }
+              }
               """
           )
         );
@@ -247,22 +252,23 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
 
     @Test
     void fieldAnnotation_shouldNotBeUpdated_whenLazyCollectionOptionIsExtra() {
+        //language=java
         rewriteRun(
           java(
             """
-                      import org.hibernate.annotations.LazyCollection;
-                      import org.hibernate.annotations.LazyCollectionOption;
-                      import jakarta.persistence.ElementCollection;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                                                                                                                      
-                          @LazyCollection(LazyCollectionOption.EXTRA)
-                          @ElementCollection
-                          private Set<Object> items;
-                      }
+              import org.hibernate.annotations.LazyCollection;
+              import org.hibernate.annotations.LazyCollectionOption;
+              import jakarta.persistence.ElementCollection;
+                                    
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                                                                                              
+                  @LazyCollection(LazyCollectionOption.EXTRA)
+                  @ElementCollection
+                  private Set<Object> items;
+              }
               """
           )
         );
@@ -271,45 +277,46 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
     @DocumentExample
     @Test
     void methodAnnotation_shouldKeepPreviousArguments_whenFetchTypeIsAdded() {
+        //language=java
         rewriteRun(
           java(
             """
-                      import org.hibernate.annotations.LazyCollection;
-                      import org.hibernate.annotations.LazyCollectionOption;
-                      import jakarta.persistence.CascadeType;
-                      import jakarta.persistence.OneToMany;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                                                      
-                          private Set<Object> items = new HashSet<>();
-                                                      
-                          @LazyCollection(LazyCollectionOption.FALSE)
-                          @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE })
-                          public Set<Object> getItems() {
-                              return items;
-                          }
-                      }
+              import org.hibernate.annotations.LazyCollection;
+              import org.hibernate.annotations.LazyCollectionOption;
+              import jakarta.persistence.CascadeType;
+              import jakarta.persistence.OneToMany;
+                                    
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                              
+                  private Set<Object> items = new HashSet<>();
+                                              
+                  @LazyCollection(LazyCollectionOption.FALSE)
+                  @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE })
+                  public Set<Object> getItems() {
+                      return items;
+                  }
+              }
               """,
             """
-                      import jakarta.persistence.CascadeType;
-                      import jakarta.persistence.FetchType;
-                      import jakarta.persistence.OneToMany;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                                                      
-                          private Set<Object> items = new HashSet<>();
-                                                      
-                          @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE }, fetch = FetchType.EAGER)
-                          public Set<Object> getItems() {
-                              return items;
-                          }
-                      }
+              import jakarta.persistence.CascadeType;
+              import jakarta.persistence.FetchType;
+              import jakarta.persistence.OneToMany;
+                                    
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                              
+                  private Set<Object> items = new HashSet<>();
+                                              
+                  @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE }, fetch = FetchType.EAGER)
+                  public Set<Object> getItems() {
+                      return items;
+                  }
+              }
               """
           )
         );
@@ -317,37 +324,38 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
 
     @Test
     void fieldAnnotation_shouldKeepPreviousArguments_whenFetchTypeIsAdded() {
+        //language=java
         rewriteRun(
           java(
             """
-                      import org.hibernate.annotations.LazyCollection;
-                      import org.hibernate.annotations.LazyCollectionOption;
-                      import jakarta.persistence.CascadeType;
-                      import jakarta.persistence.OneToMany;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
-                                                                      
-                          @LazyCollection(LazyCollectionOption.FALSE)
-                          @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE })
-                          private Set<Object> items = new HashSet<>();
-                      }
+              import org.hibernate.annotations.LazyCollection;
+              import org.hibernate.annotations.LazyCollectionOption;
+              import jakarta.persistence.CascadeType;
+              import jakarta.persistence.OneToMany;
+                                    
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
+                                                              
+                  @LazyCollection(LazyCollectionOption.FALSE)
+                  @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE })
+                  private Set<Object> items = new HashSet<>();
+              }
               """,
             """
-                      import jakarta.persistence.CascadeType;
-                      import jakarta.persistence.FetchType;
-                      import jakarta.persistence.OneToMany;
-                      
-                      import java.util.HashSet;
-                      import java.util.Set;
-                                                      
-                      public class SomeClass {
+              import jakarta.persistence.CascadeType;
+              import jakarta.persistence.FetchType;
+              import jakarta.persistence.OneToMany;
+                                    
+              import java.util.HashSet;
+              import java.util.Set;
+                                              
+              public class SomeClass {
 
-                          @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE }, fetch = FetchType.EAGER)
-                          private Set<Object> items = new HashSet<>();
-                      }
+                  @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE }, fetch = FetchType.EAGER)
+                  private Set<Object> items = new HashSet<>();
+              }
               """
           )
         );
@@ -355,6 +363,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
 
     @Test
     void allLazyCollectionAnnotationsInClass_ShouldBeProcessed() {
+        //language=java
         rewriteRun(
           java(
             """
@@ -431,6 +440,7 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
 
     @Test
     void regression_indentationIsWrong_whenSeveralAnnotationsArePresent() {
+        //language=java
         rewriteRun(
           java(
             """
@@ -484,5 +494,4 @@ public class ReplaceLazyCollectionAnnotationTest implements RewriteTest {
           )
         );
     }
-
 }

--- a/src/test/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/ReplaceLazyCollectionAnnotationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Schweizerische Bundesbahnen SBB
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
@LazyCollection is deprecated since Hibernate 6.2

Added a recipe which removes the annotation and sets the fetch type in jakarta.persistence annotations
instead.

Fixes #16 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
