### PR TITLE
feature: add recipe for hibernate 6.3 migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/hibernate-6.2.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.2.yml
@@ -39,5 +39,5 @@ recipeList:
       oldArtifactId: hypersistence-utils-hibernate-60
       newGroupId: io.hypersistence
       newArtifactId: hypersistence-utils-hibernate-62
-      newVersion: 3.6.x
+      newVersion: 3.7.x
 

--- a/src/main/resources/META-INF/rewrite/hibernate-6.3.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.3.yml
@@ -1,0 +1,43 @@
+#
+# Copyright 2023 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.hibernate.MigrateToHibernate63
+displayName: Migrate to Hibernate 6.3.x
+description: >
+  This recipe will apply changes commonly needed when migrating to Hibernate 6.3.x.
+
+recipeList:
+  - org.openrewrite.hibernate.MigrateToHypersistenceUtilsHibernate6.2
+  - org.openrewrite.hibernate.MigrateToHypersistenceUtilsHibernate6.3
+
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.hibernate.MigrateToHypersistenceUtilsHibernate6.3
+displayName: Migrate Hibernate Types to Hypersistence Utils 6.3
+description: >
+  This recipe will migrate any existing dependencies on `io.hypersistence:hypersistence-utils-hibernate-62` to `io.hypersistence:hypersistence-utils-hibernate-63`. 
+
+recipeList:
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: io.hypersistence
+      oldArtifactId: hypersistence-utils-hibernate-62
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-63
+      newVersion: 3.7.x
+

--- a/src/test/java/org/openrewrite/hibernate/MigrateToHibernate62Test.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateToHibernate62Test.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.hibernate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.config.Environment;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class MigrateToHibernate62Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(Environment.builder()
+          .scanRuntimeClasspath("org.openrewrite.hibernate")
+          .build()
+          .activateRecipes("org.openrewrite.hibernate.MigrateToHibernate62"));
+    }
+
+    @Test
+    void groupIdHypersistenceUtilsRenamedAndPackageUpdated() {
+        rewriteRun(
+          mavenProject(
+            "Sample",
+            //language=xml
+            pomXml("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>demo</artifactId>
+                  <version>0.0.1-SNAPSHOT</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>io.hypersistence</groupId>
+                      <artifactId>hypersistence-utils-hibernate-60</artifactId>
+                      <version>3.7.3</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """, spec -> spec.after(actual -> {
+                  Matcher matcher = Pattern.compile("<version>(3\\.7\\.\\d+)</version>").matcher(actual);
+                  assertTrue(matcher.find());
+                  return """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.example</groupId>
+                      <artifactId>demo</artifactId>
+                      <version>0.0.1-SNAPSHOT</version>
+                      <dependencies>
+                        <dependency>
+                          <groupId>io.hypersistence</groupId>
+                          <artifactId>hypersistence-utils-hibernate-62</artifactId>
+                          <version>%s</version>
+                        </dependency>
+                      </dependencies>
+                    </project>
+                    """.formatted(matcher.group(1));
+              })
+            )
+          )
+        );
+    }
+
+
+}

--- a/src/test/java/org/openrewrite/hibernate/MigrateToHibernate63Test.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateToHibernate63Test.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.hibernate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.config.Environment;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class MigrateToHibernate63Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(Environment.builder()
+          .scanRuntimeClasspath("org.openrewrite.hibernate")
+          .build()
+          .activateRecipes("org.openrewrite.hibernate.MigrateToHibernate63"));
+    }
+
+    @Test
+    void groupIdHypersistenceUtilsRenamedAndPackageUpdated() {
+        rewriteRun(
+          mavenProject(
+            "Sample",
+            //language=xml
+            pomXml("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>demo</artifactId>
+                  <version>0.0.1-SNAPSHOT</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>io.hypersistence</groupId>
+                      <artifactId>hypersistence-utils-hibernate-62</artifactId>
+                      <version>3.7.3</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """, spec -> spec.after(actual -> {
+                  Matcher matcher = Pattern.compile("<version>(3\\.7\\.\\d+)</version>").matcher(actual);
+                  assertTrue(matcher.find());
+                  return """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.example</groupId>
+                      <artifactId>demo</artifactId>
+                      <version>0.0.1-SNAPSHOT</version>
+                      <dependencies>
+                        <dependency>
+                          <groupId>io.hypersistence</groupId>
+                          <artifactId>hypersistence-utils-hibernate-63</artifactId>
+                          <version>%s</version>
+                        </dependency>
+                      </dependencies>
+                    </project>
+                    """.formatted(matcher.group(1));
+              })
+            )
+          )
+        );
+    }
+
+
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

- Updated `org.openrewrite.hibernate.MigrateToHibernate62` to point to newer version of `hypersistence-utils-hibernate-62`
- Add specific unit test for `org.openrewrite.hibernate.MigrateToHibernate62`
- Added a recipe to update to hibernate 6.3 with dependency change from `hypersistence-utils-hibernate-62` to `hypersistence-utils-hibernate-63`

## What's your motivation?

https://github.com/openrewrite/rewrite-hibernate/issues/22

## Anything in particular you'd like reviewers to focus on?

This is my first contribution to any open rewrite repo, so any feedback is appreciated

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
