### PR TITLE
Update Hibernate dependencies for 6.2 and 6.3

### DIFF
--- a/src/main/resources/META-INF/rewrite/hibernate-6.1.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.1.yml
@@ -55,18 +55,6 @@ recipeList:
       newGroupId: org.hibernate.orm
       newArtifactId: hibernate-agroal
       newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-agroal
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-agroal
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-agroal-jakarta
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-agroal
-      newVersion: 6.1.x
   # hibernate-c3p0
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.hibernate
@@ -75,18 +63,6 @@ recipeList:
       newArtifactId: hibernate-c3p0
       newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-c3p0-jakarta
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-c3p0
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-c3p0
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-c3p0
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
       oldGroupId: org.hibernate
       oldArtifactId: hibernate-c3p0-jakarta
       newGroupId: org.hibernate.orm
@@ -105,18 +81,6 @@ recipeList:
       newGroupId: org.hibernate.orm
       newArtifactId: hibernate-community-dialects
       newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-community-dialects
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-community-dialects
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-community-dialects-jakarta
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-community-dialects
-      newVersion: 6.1.x
     # hibernate-core
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.hibernate
@@ -125,18 +89,6 @@ recipeList:
       newArtifactId: hibernate-core
       newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-core-jakarta
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-core
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-core
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-core
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
       oldGroupId: org.hibernate
       oldArtifactId: hibernate-core-jakarta
       newGroupId: org.hibernate.orm
@@ -155,18 +107,6 @@ recipeList:
       newGroupId: org.hibernate.orm
       newArtifactId: hibernate-envers
       newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-envers
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-envers
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-envers-jakarta
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-envers
-      newVersion: 6.1.x
     # hibernate-graalvm
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.hibernate
@@ -175,18 +115,6 @@ recipeList:
       newArtifactId: hibernate-graalvm
       newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-graalvm-jakarta
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-graalvm
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-graalvm
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-graalvm
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
       oldGroupId: org.hibernate
       oldArtifactId: hibernate-graalvm-jakarta
       newGroupId: org.hibernate.orm
@@ -205,18 +133,6 @@ recipeList:
       newGroupId: org.hibernate.orm
       newArtifactId: hibernate-hikaricp
       newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-hikaricp
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-hikaricp
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-hikaricp-jakarta
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-hikaricp
-      newVersion: 6.1.x
     # hibernate-jcache
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.hibernate
@@ -225,18 +141,6 @@ recipeList:
       newArtifactId: hibernate-jcache
       newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-jcache-jakarta
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-jcache
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-jcache
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-jcache
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
       oldGroupId: org.hibernate
       oldArtifactId: hibernate-jcache-jakarta
       newGroupId: org.hibernate.orm
@@ -255,18 +159,6 @@ recipeList:
       newGroupId: org.hibernate.orm
       newArtifactId: hibernate-jpamodelgen
       newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-jpamodelgen
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-jpamodelgen
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-jpamodelgen-jakarta
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-jpamodelgen
-      newVersion: 6.1.x
     # hibernate-micrometer
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.hibernate
@@ -275,18 +167,6 @@ recipeList:
       newArtifactId: hibernate-micrometer
       newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-micrometer-jakarta
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-micrometer
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-micrometer
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-micrometer
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
       oldGroupId: org.hibernate
       oldArtifactId: hibernate-micrometer-jakarta
       newGroupId: org.hibernate.orm
@@ -305,18 +185,6 @@ recipeList:
       newGroupId: org.hibernate.orm
       newArtifactId: hibernate-proxool
       newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-proxool
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-proxool
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-proxool-jakarta
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-proxool
-      newVersion: 6.1.x
     # hibernate-spatial
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.hibernate
@@ -330,19 +198,6 @@ recipeList:
       newGroupId: org.hibernate.orm
       newArtifactId: hibernate-spatial
       newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-spatial
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-spatial
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-spatial-jakarta
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-spatial
-      newVersion: 6.1.x
-    # hibernate-testing
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.hibernate
       oldArtifactId: hibernate-testing
@@ -350,18 +205,6 @@ recipeList:
       newArtifactId: hibernate-testing
       newVersion: 6.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-testing-jakarta
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-testing
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
-      oldGroupId: org.hibernate
-      oldArtifactId: hibernate-testing
-      newGroupId: org.hibernate.orm
-      newArtifactId: hibernate-testing
-      newVersion: 6.1.x
-  - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
       oldGroupId: org.hibernate
       oldArtifactId: hibernate-testing-jakarta
       newGroupId: org.hibernate.orm

--- a/src/main/resources/META-INF/rewrite/hibernate-6.2.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.2.yml
@@ -24,7 +24,10 @@ description: >
 recipeList:
   - org.openrewrite.hibernate.MigrateToHibernate61
   - org.openrewrite.hibernate.MigrateToHypersistenceUtilsHibernate6.2
-
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.hibernate.orm
+      artifactId: '*'
+      newVersion: 6.2.x
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/hibernate-6.3.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.3.yml
@@ -24,7 +24,10 @@ description: >
 recipeList:
   - org.openrewrite.hibernate.MigrateToHypersistenceUtilsHibernate6.2
   - org.openrewrite.hibernate.MigrateToHypersistenceUtilsHibernate6.3
-
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.hibernate.orm
+      artifactId: '*'
+      newVersion: 6.3.x
 
 ---
 type: specs.openrewrite.org/v1beta/recipe


### PR DESCRIPTION
## What's changed?
- Remove superfluous `ChangeManagedDependencyGroupIdAndArtifactId`; `ChangeDependency` does that by default now.
- Add `UpgradeDependencyVersion` for the 6.2 and 6.3 migrations with use of a wildcard

## What's your motivation?
Reported via Slack as missing in 6.2 migration.