### PR TITLE
Relocate Hibernate Validator

### DIFF
--- a/src/main/resources/META-INF/rewrite/hibernate-validator.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-validator.yml
@@ -1,0 +1,29 @@
+#
+# Copyright 2023 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.hibernate.validator.HibernateValidator_8_0
+displayName: Migrate to Hibernate Validator 8.0.x
+description: >
+  This recipe will apply changes commonly needed when migrating to Hibernate Validator 8.0.x.
+
+recipeList:
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-validator
+      newGroupId: org.hibernate.validator
+      newVersion: 8.0.x

--- a/src/test/java/org/openrewrite/hibernate/validator/HibernateValidator80Test.java
+++ b/src/test/java/org/openrewrite/hibernate/validator/HibernateValidator80Test.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.hibernate.validator;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class HibernateValidator80Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.hibernate.validator.HibernateValidator_8_0");
+    }
+
+    @Test
+    void changeDependency() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example</groupId>
+                <artifactId>demo</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-validator</artifactId>
+                    <version>7.0.5.Final</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example</groupId>
+                <artifactId>demo</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.hibernate.validator</groupId>
+                    <artifactId>hibernate-validator</artifactId>
+                    <version>8.0.1.Final</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/hibernate/validator/HibernateValidator80Test.java
+++ b/src/test/java/org/openrewrite/hibernate/validator/HibernateValidator80Test.java
@@ -16,6 +16,7 @@
 package org.openrewrite.hibernate.validator;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -28,6 +29,7 @@ class HibernateValidator80Test implements RewriteTest {
         spec.recipeFromResources("org.openrewrite.hibernate.validator.HibernateValidator_8_0");
     }
 
+    @DocumentExample
     @Test
     void changeDependency() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
Relocate Hibernate Validator dependency as part of the 8.0 upgrade.

## What's your motivation?
GroupId was updated; we'll want to use the new coordinates going forward.