### PR TITLE
Hibernate 6.4 and 6.5 migration recipes

### DIFF
--- a/src/main/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectation.java
+++ b/src/main/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectation.java
@@ -59,13 +59,6 @@ public class MigrateResultCheckStyleToExpectation extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaIsoVisitor<ExecutionContext>() {
-
-            @Override
-            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
-                return super.visitCompilationUnit(cu, ctx);
-                return super.visitCompilationUnit(cu, executionContext);
-            }
-
             @Override
             public J.Annotation visitAnnotation(J.Annotation annotationn, ExecutionContext ctx) {
                 if (ANNOTATION_MATCHERS.stream().anyMatch(m -> m.matches(annotationn))) {
@@ -92,7 +85,7 @@ public class MigrateResultCheckStyleToExpectation extends Recipe {
 
                                     maybeAddImport("org.hibernate.jdbc.Expectation");
                                     maybeRemoveImport("org.hibernate.annotations.ResultCheckStyle");
-                                    new ShortenFullyQualifiedTypeReferences().getVisitor().visit(a, ctx);
+                                    doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
                                     return a;
                                 }
                             }

--- a/src/main/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectation.java
+++ b/src/main/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectation.java
@@ -36,9 +36,9 @@ public class MigrateResultCheckStyleToExpectation extends Recipe {
     private static final Set<AnnotationMatcher> ANNOTATION_MATCHERS;
 
     static {
-        MAPPING.put("ResultCheckStyle.NONE", "org.hibernate.jdbc.Expectation.None.class");
-        MAPPING.put("ResultCheckStyle.COUNT", "org.hibernate.jdbc.Expectation.RowCount.class");
-        MAPPING.put("ResultCheckStyle.PARAM", "org.hibernate.jdbc.Expectation.OutParameter.class");
+        MAPPING.put("NONE", "org.hibernate.jdbc.Expectation.None.class");
+        MAPPING.put("COUNT", "org.hibernate.jdbc.Expectation.RowCount.class");
+        MAPPING.put("PARAM", "org.hibernate.jdbc.Expectation.OutParameter.class");
 
         ANNOTATION_MATCHERS =
                 Stream.of("SQLInsert", "SQLUpdate", "SQLDelete", "SQLDeleteAll")
@@ -115,11 +115,14 @@ public class MigrateResultCheckStyleToExpectation extends Recipe {
             }
 
             private @Nullable String getMappingForResultCheck(J.Assignment assignment) {
-                return MAPPING.entrySet().stream()
-                        .filter(entry -> assignment.getAssignment().toString().contains(entry.getKey()))
-                        .map(Map.Entry::getValue)
-                        .findFirst()
-                        .orElse(null);
+                Expression value = assignment.getAssignment();
+                if (value instanceof J.FieldAccess) {
+                    return MAPPING.get(((J.FieldAccess) value).getSimpleName());
+                }
+                if (value instanceof J.Identifier) {
+                    return MAPPING.get(((J.Identifier) value).getSimpleName());
+                }
+                return null;
             }
         });
     }

--- a/src/main/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectation.java
+++ b/src/main/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.hibernate;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.search.UsesType;
+
+public class MigrateResultCheckStyleToExpectation extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Migration of ResultCheckStyle to Expectation";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Will migrate the usage of org.hibernate.annotations.ResultCheckStyle to org.hibernate.jdbc.Expectation" +
+                "in the @SQLInsert annotation.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new UsesType<>("jakarta.persistence.ResultCheckStyle", false),
+                super.getVisitor());
+    }
+}

--- a/src/main/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectation.java
+++ b/src/main/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectation.java
@@ -25,7 +25,10 @@ import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toSet;

--- a/src/main/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectation.java
+++ b/src/main/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectation.java
@@ -15,13 +15,36 @@
  */
 package org.openrewrite.hibernate;
 
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
-import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.*;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class MigrateResultCheckStyleToExpectation extends Recipe {
+
+    private static final Map<String, String> MAPPING = new HashMap<>();
+    private static final Set<AnnotationMatcher> ANNOTATION_MATCHERS;
+
+    static {
+        MAPPING.put("ResultCheckStyle.NONE", "org.hibernate.jdbc.Expectation.None.class");
+        MAPPING.put("ResultCheckStyle.COUNT", "org.hibernate.jdbc.Expectation.RowCount.class");
+        MAPPING.put("ResultCheckStyle.PARAM", "org.hibernate.jdbc.Expectation.OutParameter.class");
+
+        ANNOTATION_MATCHERS = Stream.of("SQLInsert", "SQLUpdate", "SQLDelete", "SQLDeleteAll").map(annotationName ->
+                        new AnnotationMatcher("@org.hibernate.annotations." + annotationName, true))
+                .collect(Collectors.toSet());
+    }
 
     @Override
     public String getDisplayName() {
@@ -30,14 +53,61 @@ public class MigrateResultCheckStyleToExpectation extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Will migrate the usage of org.hibernate.annotations.ResultCheckStyle to org.hibernate.jdbc.Expectation" +
-                "in the @SQLInsert annotation.";
+        return "Will migrate the usage of `org.hibernate.annotations.ResultCheckStyle` to `org.hibernate.jdbc.Expectation`" +
+               "in the `@SQLInsert` annotation.";
     }
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(
-                new UsesType<>("jakarta.persistence.ResultCheckStyle", false),
-                super.getVisitor());
+        return new JavaIsoVisitor<ExecutionContext>() {
+
+            @Override
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
+                doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
+                return super.visitCompilationUnit(cu, executionContext);
+            }
+
+            @Override
+            public J.Annotation visitAnnotation(J.Annotation annotationn, ExecutionContext executionContext) {
+                if (ANNOTATION_MATCHERS.stream().anyMatch(m -> m.matches(annotationn))) {
+                    J.Annotation a = super.visitAnnotation(annotationn, executionContext);
+                    List<Expression> arguments = a.getArguments();
+
+                    for (int i = 0; i < arguments.size(); i++) {
+                        if (arguments.get(i) instanceof J.Assignment &&
+                            (((J.Assignment) arguments.get(i)).getVariable() instanceof J.Identifier)) {
+
+                            // Each argument should be an assignment
+                            J.Assignment assignment = (J.Assignment) arguments.get(i);
+                            // Each assignment should have a
+                            J.Identifier identifier = (J.Identifier) assignment.getVariable();
+
+                            if ("check".equals(identifier.getSimpleName())) {
+                                String map = getMappingForResultCheck(assignment);
+                                if (map != null) {
+                                    a = JavaTemplate.builder("verify = #{}")
+                                            .build()
+                                            .apply(getCursor(), assignment.getCoordinates().replace(), map);
+
+                                    maybeAddImport(map);
+                                    doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
+                                    return a;
+                                }
+                            }
+                        }
+                    }
+                }
+                return annotationn;
+            }
+
+            private @Nullable  String getMappingForResultCheck(J.Assignment assignment) {
+                for (Map.Entry<String, String> entry : MAPPING.entrySet()) {
+                    if (assignment.getAssignment().toString().contains(entry.getKey())) {
+                        return entry.getValue();
+                    }
+                }
+                return null;
+            }
+        };
     }
 }

--- a/src/main/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectation.java
+++ b/src/main/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectation.java
@@ -61,8 +61,8 @@ public class MigrateResultCheckStyleToExpectation extends Recipe {
         return new JavaIsoVisitor<ExecutionContext>() {
 
             @Override
-            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
-                doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                return super.visitCompilationUnit(cu, ctx);
                 return super.visitCompilationUnit(cu, executionContext);
             }
 

--- a/src/main/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotation.java
+++ b/src/main/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotation.java
@@ -49,7 +49,7 @@ public class RemoveInvalidHibernateGeneratedValueAnnotation extends Recipe {
                 new UsesType<>("jakarta.persistence.GeneratedValue", false),
                 new JavaIsoVisitor<ExecutionContext>() {
                     @Override
-                    public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext executionContext) {
+                    public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
                         if (MATCHER_GENERATED_VALUE_ANNOTATION.matches(annotation) && !containsBoth()) {
                             doAfterVisit(new RemoveAnnotationVisitor(getAnnotationMatcher(annotation)));
                         }

--- a/src/main/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotation.java
+++ b/src/main/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotation.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.hibernate;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.search.UsesType;
+
+public class RemoveInvalidHibernateGeneratedValueAnnotation extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Remove invalid `@GeneratedValue` annotation";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Removes `@GeneratedValue` annotation from fields that are not also annotated with `@Id`.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new UsesType<>("jakarta.persistence.GeneratedValue", false),
+                super.getVisitor());
+    }
+}

--- a/src/main/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotation.java
+++ b/src/main/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotation.java
@@ -15,13 +15,27 @@
  */
 package org.openrewrite.hibernate;
 
+import org.jspecify.annotations.NonNull;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.RemoveAnnotationVisitor;
 import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.service.AnnotationService;
+import org.openrewrite.java.tree.J;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class RemoveInvalidHibernateGeneratedValueAnnotation extends Recipe {
+
+    private static final AnnotationMatcher MATCHER_GENERATED_VALUE_ANNOTATION
+            = new AnnotationMatcher("@jakarta.persistence.GeneratedValue", true);
+    private static final AnnotationMatcher MATCHER_ID_ANNOTATION
+            = new AnnotationMatcher("@jakarta.persistence.Id", true);
 
     @Override
     public String getDisplayName() {
@@ -37,6 +51,42 @@ public class RemoveInvalidHibernateGeneratedValueAnnotation extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
                 new UsesType<>("jakarta.persistence.GeneratedValue", false),
-                super.getVisitor());
+                new JavaIsoVisitor<ExecutionContext>() {
+                    @Override
+                    public J preVisit(@NonNull J tree, ExecutionContext executionContext) {
+                        stopAfterPreVisit();
+
+                        Set<J.Annotation> invalidAnnotations = new RemoveInvalidHibernateGeneratedValueAnnotationVisitor().reduce(tree, new HashSet<>());
+                        if (!invalidAnnotations.isEmpty()) {
+                            AnnotationMatcher customMatcher = new AnnotationMatcher(
+                                    // ignored in practice, as we only match annotations previously found just above
+                                    "@jakarta.persistence.GeneratedValue", true) {
+                                @Override
+                                public boolean matches(J.Annotation annotation) {
+                                    return invalidAnnotations.contains(annotation);
+                                }
+                            };
+                            doAfterVisit(new RemoveAnnotationVisitor(customMatcher));
+                        }
+                        return tree;
+                    }
+                });
+    }
+
+    static class RemoveInvalidHibernateGeneratedValueAnnotationVisitor extends JavaIsoVisitor<Set<J.Annotation>> {
+        @Override
+        public J.Annotation visitAnnotation(J.Annotation a, Set<J.Annotation> accumulator) {
+            if (MATCHER_GENERATED_VALUE_ANNOTATION.matches(a) && !containsBoth()) {
+                accumulator.add(a);
+            }
+            return a;
+        }
+
+        private boolean containsBoth() {
+            return service(AnnotationService.class)
+                    .getAllAnnotations(getCursor().getParentOrThrow())
+                    .stream()
+                    .anyMatch(MATCHER_ID_ANNOTATION::matches);
+        }
     }
 }

--- a/src/main/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotation.java
+++ b/src/main/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotation.java
@@ -50,20 +50,14 @@ public class RemoveInvalidHibernateGeneratedValueAnnotation extends Recipe {
                 new JavaIsoVisitor<ExecutionContext>() {
                     @Override
                     public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
-                        if (MATCHER_GENERATED_VALUE_ANNOTATION.matches(annotation) && !containsBoth()) {
-                            doAfterVisit(new RemoveAnnotationVisitor(getAnnotationMatcher(annotation)));
+                        if (MATCHER_GENERATED_VALUE_ANNOTATION.matches(annotation) &&
+                            !service(AnnotationService.class).matches(getCursor().getParentTreeCursor(), MATCHER_ID_ANNOTATION)) {
+                            doAfterVisit(new RemoveAnnotationVisitor(specificAnnotationMatcher(annotation)));
                         }
                         return annotation;
                     }
 
-                    private boolean containsBoth() {
-                        return service(AnnotationService.class)
-                                .getAllAnnotations(getCursor().getParentOrThrow())
-                                .stream()
-                                .anyMatch(MATCHER_ID_ANNOTATION::matches);
-                    }
-
-                    private AnnotationMatcher getAnnotationMatcher(J.Annotation annotation) {
+                    private AnnotationMatcher specificAnnotationMatcher(J.Annotation annotation) {
                         return new AnnotationMatcher(
                                 // ignored in practice, as we only match annotations previously found just above
                                 "@jakarta.persistence.GeneratedValue", true) {

--- a/src/main/resources/META-INF/rewrite/hibernate-6.3.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.3.yml
@@ -34,7 +34,7 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.hibernate.MigrateToHypersistenceUtilsHibernate6.3
 displayName: Migrate Hibernate Types to Hypersistence Utils 6.3
 description: >-
-  This recipe will migrate any existing dependencies on `io.hypersistence:hypersistence-utils-hibernate-62` to `io.hypersistence:hypersistence-utils-hibernate-63`. 
+  This recipe will migrate any existing dependencies on `io.hypersistence:hypersistence-utils-hibernate-62` to `io.hypersistence:hypersistence-utils-hibernate-63`.
 
 recipeList:
   - org.openrewrite.java.dependencies.ChangeDependency:
@@ -42,5 +42,5 @@ recipeList:
       oldArtifactId: hypersistence-utils-hibernate-62
       newGroupId: io.hypersistence
       newArtifactId: hypersistence-utils-hibernate-63
-      newVersion: 3.7.x
+      newVersion: 3.8.x
 

--- a/src/main/resources/META-INF/rewrite/hibernate-6.4.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.4.yml
@@ -1,0 +1,30 @@
+#
+# Copyright 2024 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.hibernate.MigrateToHibernate64
+displayName: Migrate to Hibernate 6.4.x
+description: >-
+  This recipe will apply changes commonly needed when migrating to Hibernate 6.4.x.
+
+recipeList:
+  - org.openrewrite.hibernate.MigrateToHibernate63
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.hibernate.orm
+      artifactId: '*'
+      newVersion: 6.4.x
+  - org.openrewrite.hibernate.RemoveInvalidHibernateGeneratedValuesAnnotation

--- a/src/main/resources/META-INF/rewrite/hibernate-6.5.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.5.yml
@@ -22,7 +22,7 @@ description: >-
   This recipe will apply changes commonly needed when migrating to Hibernate 6.5.x.
 
 recipeList:
-  - org.openrewrite.hibernate.MigrateToHibernate63
+  - org.openrewrite.hibernate.MigrateToHibernate64
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.hibernate.orm
       artifactId: '*'

--- a/src/main/resources/META-INF/rewrite/hibernate-6.5.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.5.yml
@@ -1,0 +1,30 @@
+#
+# Copyright 2024 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.hibernate.MigrateToHibernate65
+displayName: Migrate to Hibernate 6.5.x
+description: >-
+  This recipe will apply changes commonly needed when migrating to Hibernate 6.5.x.
+
+recipeList:
+  - org.openrewrite.hibernate.MigrateToHibernate63
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.hibernate.orm
+      artifactId: '*'
+      newVersion: 6.5.x
+  - org.openrewrite.hibernate.MigrateResultCheckStyleToExpectation

--- a/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.hibernate;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.openrewrite.DocumentExample;
@@ -66,6 +67,31 @@ class MigrateResultCheckStyleToExpectationTest implements RewriteTest {
               @%1$s(verify = %2$s, sql = "")
               class A {}
               """.formatted(annotation, newExpectationValue)
+          )
+        );
+    }
+
+    @Test
+    void staticImportTest() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import org.hibernate.annotations.SQLInsert;
+              import org.hibernate.annotations.ResultCheckStyle;
+
+              import static org.hibernate.annotations.ResultCheckStyle.NONE;
+
+              @SQLInsert(check = NONE, sql = "")
+              class A {}
+              """,
+            """
+              import org.hibernate.annotations.SQLInsert;
+              import org.hibernate.jdbc.Expectation;
+
+              @SQLInsert(verify = Expectation.None.class, sql = "")
+              class A {}
+              """
           )
         );
     }

--- a/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.hibernate;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -57,7 +58,8 @@ class MigrateResultCheckStyleToExpectationTest implements RewriteTest {
     void migrateSqlInsertCountToExpectationRowCount() {
         // language=java
         rewriteRun(
-          java("""
+          java(
+          """
             import org.hibernate.annotations.SQLInsert;
             import org.hibernate.engine.spi.ResultCheckStyle;
 
@@ -77,7 +79,8 @@ class MigrateResultCheckStyleToExpectationTest implements RewriteTest {
     void migrateSqlInsertParamToExpectationOutParameter() {
         // language=java
         rewriteRun(
-          java("""
+          java(
+          """
             import org.hibernate.annotations.SQLInsert;
             import org.hibernate.engine.spi.ResultCheckStyle;
 

--- a/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
@@ -19,7 +19,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.search.FindAnnotations;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -43,6 +45,8 @@ class MigrateResultCheckStyleToExpectationTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(), "hibernate-core-6.5+")
           );
+
+
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
@@ -19,9 +19,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
-import org.openrewrite.java.search.FindAnnotations;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -56,14 +54,14 @@ class MigrateResultCheckStyleToExpectationTest implements RewriteTest {
         // language=java
         rewriteRun(
           java(
-              """
+            """
               import org.hibernate.annotations.%1$s;
               import org.hibernate.annotations.ResultCheckStyle;
 
               @%1$s(check = %2$s, sql = "")
               class A {}
               """.formatted(annotation, oldResultCheckStyleValue),
-              """
+            """
               import org.hibernate.annotations.%1$s;
               import org.hibernate.jdbc.Expectation;
 

--- a/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
@@ -52,13 +52,14 @@ class MigrateResultCheckStyleToExpectationTest implements RewriteTest {
         // language=java
         rewriteRun(
           java(
-            """
+              """
               import org.hibernate.annotations.%1$s;
               import org.hibernate.annotations.ResultCheckStyle;
 
               @%1$s(check = %2$s, sql = "")
               class A {}
-              """.formatted(annotation, oldResultCheckStyleValue), """
+              """.formatted(annotation, oldResultCheckStyleValue),
+              """
               import org.hibernate.annotations.%1$s;
               import org.hibernate.jdbc.Expectation;
 

--- a/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
@@ -30,29 +30,27 @@ import static org.openrewrite.java.Assertions.java;
 class MigrateResultCheckStyleToExpectationTest implements RewriteTest {
 
     static Stream<String[]> generateTestParameters() {
-        return Stream.of("SQLInsert", "SQLUpdate", "SQLDelete", "SQLDeleteAll").map(annotation -> new String[][]{
-          new String[]{annotation, "ResultCheckStyle.NONE", "Expectation.None.class"},
-          new String[]{annotation, "ResultCheckStyle.COUNT", "Expectation.RowCount.class"},
-          new String[]{annotation, "ResultCheckStyle.PARAM", "Expectation.OutParameter.class"}
-        }).flatMap(Stream::of);
+        return Stream.of("SQLInsert", "SQLUpdate", "SQLDelete", "SQLDeleteAll")
+          .map(annotation -> new String[][]{
+            new String[]{annotation, "ResultCheckStyle.NONE", "Expectation.None.class"},
+            new String[]{annotation, "ResultCheckStyle.COUNT", "Expectation.RowCount.class"},
+            new String[]{annotation, "ResultCheckStyle.PARAM", "Expectation.OutParameter.class"}
+          })
+          .flatMap(Stream::of);
     }
 
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateResultCheckStyleToExpectation())
-          .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "hibernate-core-6.5+")
-          );
-
-
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "hibernate-core-6.5+"));
     }
 
     @DocumentExample
     @ParameterizedTest
     @MethodSource("generateTestParameters")
     void shouldMigrateResultCheckStyleToExpectationNone(String annotation, String oldResultCheckStyleValue, String newExpectationValue) {
-        // language=java
         rewriteRun(
+          // language=java
           java(
             """
               import org.hibernate.annotations.%1$s;
@@ -68,6 +66,7 @@ class MigrateResultCheckStyleToExpectationTest implements RewriteTest {
               @%1$s(verify = %2$s, sql = "")
               class A {}
               """.formatted(annotation, newExpectationValue)
-          ));
+          )
+        );
     }
 }

--- a/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.hibernate;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.openrewrite.DocumentExample;
@@ -39,7 +40,7 @@ class MigrateResultCheckStyleToExpectationTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new RemoveInvalidHibernateGeneratedValueAnnotation())
+        spec.recipe(new MigrateResultCheckStyleToExpectation())
                 .parser(JavaParser.fromJavaVersion()
                         .classpathFromResources(new InMemoryExecutionContext(), "hibernate-core-6.5+")
                 );
@@ -54,9 +55,9 @@ class MigrateResultCheckStyleToExpectationTest implements RewriteTest {
           java(
             """
             import org.hibernate.annotations.%1$s;
-            import org.hibernate.engine.spi.ResultCheckStyle;
+            import org.hibernate.annotations.ResultCheckStyle;
 
-            @%1$s(check = %2$s)
+            @%1$s(check = %2$s, sql = "")
             class A {}
             """.formatted(annotation, oldResultCheckStyleValue), """
             import org.hibernate.annotations.%1$s;

--- a/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.hibernate;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -38,8 +37,8 @@ class MigrateResultCheckStyleToExpectationTest implements RewriteTest {
     void migrateSqlInsertNoneToExpectationNone() {
         // language=java
         rewriteRun(
-          java("""
-            import org.hibernate.annotations.SQLInsert;
+          java(
+          """
             import org.hibernate.engine.spi.ResultCheckStyle;
 
             @SQLInsert(check = ResultCheckStyle.NONE)

--- a/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.hibernate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class MigrateResultCheckStyleToExpectationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveInvalidHibernateGeneratedValueAnnotation())
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "hibernate-core-6.5+")
+          );
+    }
+
+    @Test
+    void migrateSqlInsertNoneToExpectationNone() {
+        // language=java
+        rewriteRun(
+          java("""
+            import org.hibernate.annotations.SQLInsert;
+            import org.hibernate.engine.spi.ResultCheckStyle;
+
+            @SQLInsert(check = ResultCheckStyle.NONE)
+            class A {}
+            """, """
+            import org.hibernate.annotations.SQLInsert;
+            import org.hibernate.jdbc.Expectation;
+
+            @SQLInsert(verify = Expectation.None.class, sql = "")
+            class A {}
+            """
+          ));
+    }
+
+    @Test
+    void migrateSqlInsertCountToExpectationRowCount() {
+        // language=java
+        rewriteRun(
+          java("""
+            import org.hibernate.annotations.SQLInsert;
+            import org.hibernate.engine.spi.ResultCheckStyle;
+
+            @SQLInsert(check = ResultCheckStyle.COUNT, sql = "")
+            class A {}
+            """, """
+            import org.hibernate.annotations.SQLInsert;
+            import org.hibernate.jdbc.Expectation;
+
+            @SQLInsert(verify = Expectation.RowCount.class, sql = "")
+            class A {}
+            """
+          ));
+    }
+
+    @Test
+    void migrateSqlInsertParamToExpectationOutParameter() {
+        // language=java
+        rewriteRun(
+          java("""
+            import org.hibernate.annotations.SQLInsert;
+            import org.hibernate.engine.spi.ResultCheckStyle;
+
+            @SQLInsert(check = ResultCheckStyle.PARAM, sql = "")
+            class A {}
+            """, """
+            import org.hibernate.annotations.SQLInsert;
+            import org.hibernate.jdbc.Expectation;
+
+            @SQLInsert(verify = Expectation.OutParameter.class, sql = "")
+            class A {}
+            """
+          ));
+    }
+}

--- a/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.hibernate;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.openrewrite.DocumentExample;
@@ -32,18 +31,18 @@ class MigrateResultCheckStyleToExpectationTest implements RewriteTest {
 
     static Stream<String[]> generateTestParameters() {
         return Stream.of("SQLInsert", "SQLUpdate", "SQLDelete", "SQLDeleteAll").map(annotation -> new String[][]{
-                new String[]{annotation, "ResultCheckStyle.NONE", "Expectation.None.class"},
-                new String[]{annotation, "ResultCheckStyle.COUNT", "Expectation.RowCount.class"},
-                new String[]{annotation, "ResultCheckStyle.PARAM", "Expectation.OutParameter.class"}
+          new String[]{annotation, "ResultCheckStyle.NONE", "Expectation.None.class"},
+          new String[]{annotation, "ResultCheckStyle.COUNT", "Expectation.RowCount.class"},
+          new String[]{annotation, "ResultCheckStyle.PARAM", "Expectation.OutParameter.class"}
         }).flatMap(Stream::of);
     }
 
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateResultCheckStyleToExpectation())
-                .parser(JavaParser.fromJavaVersion()
-                        .classpathFromResources(new InMemoryExecutionContext(), "hibernate-core-6.5+")
-                );
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "hibernate-core-6.5+")
+          );
     }
 
     @DocumentExample
@@ -54,19 +53,18 @@ class MigrateResultCheckStyleToExpectationTest implements RewriteTest {
         rewriteRun(
           java(
             """
-            import org.hibernate.annotations.%1$s;
-            import org.hibernate.annotations.ResultCheckStyle;
+              import org.hibernate.annotations.%1$s;
+              import org.hibernate.annotations.ResultCheckStyle;
 
-            @%1$s(check = %2$s, sql = "")
-            class A {}
-            """.formatted(annotation, oldResultCheckStyleValue), """
-            import org.hibernate.annotations.%1$s;
-            import org.hibernate.jdbc.Expectation;
+              @%1$s(check = %2$s, sql = "")
+              class A {}
+              """.formatted(annotation, oldResultCheckStyleValue), """
+              import org.hibernate.annotations.%1$s;
+              import org.hibernate.jdbc.Expectation;
 
-            @%1$s(verify = %2$s, sql = "")
-            class A {}
-            """.formatted(annotation, newExpectationValue)
-          )
-        );
+              @%1$s(verify = %2$s, sql = "")
+              class A {}
+              """.formatted(annotation, newExpectationValue)
+          ));
     }
 }

--- a/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateResultCheckStyleToExpectationTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.hibernate;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -33,6 +34,7 @@ class MigrateResultCheckStyleToExpectationTest implements RewriteTest {
           );
     }
 
+    @DocumentExample
     @Test
     void migrateSqlInsertNoneToExpectationNone() {
         // language=java

--- a/src/test/java/org/openrewrite/hibernate/MigrateToHibernate63Test.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateToHibernate63Test.java
@@ -60,7 +60,7 @@ class MigrateToHibernate63Test implements RewriteTest {
                   </dependencies>
                 </project>
                 """, spec -> spec.after(actual -> {
-                  Matcher matcher = Pattern.compile("<version>(3\\.7\\.\\d+)</version>").matcher(actual);
+                  Matcher matcher = Pattern.compile("<version>(3\\.8\\.\\d+)</version>").matcher(actual);
                   assertTrue(matcher.find());
                   return """
                     <?xml version="1.0" encoding="UTF-8"?>

--- a/src/test/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotationTest.java
@@ -39,7 +39,8 @@ class RemoveInvalidHibernateGeneratedValueAnnotationTest implements RewriteTest 
     void removeIncorrectlyPlacedGenerateValue() {
         //language=java
         rewriteRun(
-          java("""
+          java(
+          """
             import jakarta.persistence.Entity;
             import jakarta.persistence.GeneratedValue;
             import jakarta.persistence.Id;
@@ -69,7 +70,8 @@ class RemoveInvalidHibernateGeneratedValueAnnotationTest implements RewriteTest 
     void shouldNotRemoveCorrectlyPlacedGenerateValue() {
         //language=java
         rewriteRun(
-          java("""
+          java(
+          """
             import jakarta.persistence.Entity;
             import jakarta.persistence.GeneratedValue;
             import jakarta.persistence.Id;
@@ -88,7 +90,8 @@ class RemoveInvalidHibernateGeneratedValueAnnotationTest implements RewriteTest 
     void shouldOnlyRemoveIncorreclyPlacedGenerateValueButPreserveOthers() {
         //language=java
         rewriteRun(
-          java("""
+          java(
+          """
             import jakarta.persistence.Entity;
             import jakarta.persistence.GeneratedValue;
             import jakarta.persistence.Id;

--- a/src/test/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotationTest.java
@@ -100,7 +100,8 @@ class RemoveInvalidHibernateGeneratedValueAnnotationTest implements RewriteTest 
                 @GeneratedValue
                 String name;
             }
-            """, """
+            """,
+            """
             import jakarta.persistence.Entity;
             import jakarta.persistence.GeneratedValue;
             import jakarta.persistence.Id;

--- a/src/test/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotationTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.hibernate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveInvalidHibernateGeneratedValueAnnotationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveInvalidHibernateGeneratedValueAnnotation())
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "jakarta.persistence")
+          );
+    }
+
+    @DocumentExample
+    @Test
+    void removeIncorrectlyPlacedGenerateValue() {
+        //language=java
+        rewriteRun(
+          java("""
+            import jakarta.persistence.Entity;
+            import jakarta.persistence.GeneratedValue;
+            import jakarta.persistence.Id;
+
+            @Entity
+            class A {
+                @Id
+                Integer id;
+                @GeneratedValue
+                String name;
+            }
+            """, """
+            import jakarta.persistence.Entity;
+            import jakarta.persistence.Id;
+
+            @Entity
+            class A {
+                @Id
+                Integer id;
+                String name;
+            }
+            """
+          ));
+    }
+
+    @Test
+    void shouldNotRemoveCorrectlyPlacedGenerateValue() {
+        //language=java
+        rewriteRun(
+          java("""
+            import jakarta.persistence.Entity;
+            import jakarta.persistence.GeneratedValue;
+            import jakarta.persistence.Id;
+
+            @Entity
+            class A {
+                @Id
+                @GeneratedValue
+                Integer id;
+            }
+            """
+          ));
+    }
+
+    @Test
+    void shouldOnlyRemoveIncorreclyPlacedGenerateValueButPreserveOthers() {
+        //language=java
+        rewriteRun(
+          java("""
+            import jakarta.persistence.Entity;
+            import jakarta.persistence.GeneratedValue;
+            import jakarta.persistence.Id;
+
+            @Entity
+            class A {
+                @Id
+                @GeneratedValue
+                Integer id;
+                @GeneratedValue
+                String name;
+            }
+            """, """
+            import jakarta.persistence.Entity;
+            import jakarta.persistence.GeneratedValue;
+            import jakarta.persistence.Id;
+
+            @Entity
+            class A {
+                @Id
+                @GeneratedValue
+                Integer id;
+                String name;
+            }
+            """
+          ));
+    }
+}

--- a/src/test/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotationTest.java
@@ -29,91 +29,92 @@ class RemoveInvalidHibernateGeneratedValueAnnotationTest implements RewriteTest 
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new RemoveInvalidHibernateGeneratedValueAnnotation())
-          .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "jakarta.persistence")
-          );
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "jakarta.persistence"));
     }
 
     @DocumentExample
     @Test
     void removeIncorrectlyPlacedGenerateValue() {
-        //language=java
         rewriteRun(
+          //language=java
           java(
-          """
-            import jakarta.persistence.Entity;
-            import jakarta.persistence.GeneratedValue;
-            import jakarta.persistence.Id;
-
-            class A {
-                @Id
-                Integer id;
-                @GeneratedValue
-                String name;
-            }
-            """,
             """
-            import jakarta.persistence.Entity;
-            import jakarta.persistence.Id;
+              import jakarta.persistence.Entity;
+              import jakarta.persistence.GeneratedValue;
+              import jakarta.persistence.Id;
 
-            class A {
-                @Id
-                Integer id;
-                String name;
-            }
+              class A {
+                  @Id
+                  Integer id;
+                  @GeneratedValue
+                  String name;
+              }
+              """,
             """
-          ));
+              import jakarta.persistence.Entity;
+              import jakarta.persistence.Id;
+
+              class A {
+                  @Id
+                  Integer id;
+                  String name;
+              }
+              """
+          )
+        );
     }
 
     @Test
     void shouldNotRemoveCorrectlyPlacedGenerateValue() {
-        //language=java
         rewriteRun(
+          //language=java
           java(
-          """
-            import jakarta.persistence.Entity;
-            import jakarta.persistence.GeneratedValue;
-            import jakarta.persistence.Id;
-
-            class A {
-                @Id
-                @GeneratedValue
-                Integer id;
-            }
             """
-          ));
+              import jakarta.persistence.Entity;
+              import jakarta.persistence.GeneratedValue;
+              import jakarta.persistence.Id;
+
+              class A {
+                  @Id
+                  @GeneratedValue
+                  Integer id;
+              }
+              """
+          )
+        );
     }
 
     @Test
     void shouldOnlyRemoveIncorreclyPlacedGenerateValueButPreserveOthers() {
-        //language=java
         rewriteRun(
+          //language=java
           java(
-          """
-            import jakarta.persistence.Entity;
-            import jakarta.persistence.GeneratedValue;
-            import jakarta.persistence.Id;
-
-            class A {
-                @Id
-                @GeneratedValue
-                Integer id;
-                @GeneratedValue
-                String name;
-            }
-            """,
             """
-            import jakarta.persistence.Entity;
-            import jakarta.persistence.GeneratedValue;
-            import jakarta.persistence.Id;
+              import jakarta.persistence.Entity;
+              import jakarta.persistence.GeneratedValue;
+              import jakarta.persistence.Id;
 
-            class A {
-                @Id
-                @GeneratedValue
-                Integer id;
-                String name;
-            }
+              class A {
+                  @Id
+                  @GeneratedValue
+                  Integer id;
+                  @GeneratedValue
+                  String name;
+              }
+              """,
             """
-          ));
+              import jakarta.persistence.Entity;
+              import jakarta.persistence.GeneratedValue;
+              import jakarta.persistence.Id;
+
+              class A {
+                  @Id
+                  @GeneratedValue
+                  Integer id;
+                  String name;
+              }
+              """
+          )
+        );
     }
 }

--- a/src/test/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotationTest.java
@@ -51,7 +51,8 @@ class RemoveInvalidHibernateGeneratedValueAnnotationTest implements RewriteTest 
                 @GeneratedValue
                 String name;
             }
-            """, """
+            """,
+            """
             import jakarta.persistence.Entity;
             import jakarta.persistence.Id;
 

--- a/src/test/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotationTest.java
+++ b/src/test/java/org/openrewrite/hibernate/RemoveInvalidHibernateGeneratedValueAnnotationTest.java
@@ -45,7 +45,6 @@ class RemoveInvalidHibernateGeneratedValueAnnotationTest implements RewriteTest 
             import jakarta.persistence.GeneratedValue;
             import jakarta.persistence.Id;
 
-            @Entity
             class A {
                 @Id
                 Integer id;
@@ -56,7 +55,6 @@ class RemoveInvalidHibernateGeneratedValueAnnotationTest implements RewriteTest 
             import jakarta.persistence.Entity;
             import jakarta.persistence.Id;
 
-            @Entity
             class A {
                 @Id
                 Integer id;
@@ -76,7 +74,6 @@ class RemoveInvalidHibernateGeneratedValueAnnotationTest implements RewriteTest 
             import jakarta.persistence.GeneratedValue;
             import jakarta.persistence.Id;
 
-            @Entity
             class A {
                 @Id
                 @GeneratedValue
@@ -96,7 +93,6 @@ class RemoveInvalidHibernateGeneratedValueAnnotationTest implements RewriteTest 
             import jakarta.persistence.GeneratedValue;
             import jakarta.persistence.Id;
 
-            @Entity
             class A {
                 @Id
                 @GeneratedValue
@@ -109,7 +105,6 @@ class RemoveInvalidHibernateGeneratedValueAnnotationTest implements RewriteTest 
             import jakarta.persistence.GeneratedValue;
             import jakarta.persistence.Id;
 
-            @Entity
             class A {
                 @Id
                 @GeneratedValue


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
This PR adds two recipes that will automatically migrating to Hibernate 6.4 and 6.5.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
@timtebeek @Laurens-W 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
The test have been constructed based on the official Hibernate migration guidelines.

* https://docs.jboss.org/hibernate/orm/6.4/migration-guide/migration-guide.html
* https://docs.jboss.org/hibernate/orm/6.5/migration-guide/migration-guide.html


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
