### PR TITLE
Fix empty diff test failure from upstream JavaSourceSet marker updates

### DIFF
--- a/src/test/java/org/openrewrite/hibernate/MigrateToHibernate61Test.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateToHibernate61Test.java
@@ -151,6 +151,10 @@ class MigrateToHibernate61Test implements RewriteTest {
               java("""
                 public class TestApplication {
                 }
+                """,
+                """
+                public class TestApplication {
+                }
                 """
               )
             )


### PR DESCRIPTION
## Summary
- Fixes `MigrateToHibernate61Test.groupIdHibernateOrmRenamed()` failing with "An empty diff was generated"
- Caused by openrewrite/rewrite#7202 which added `JavaSourceSet` marker updates to `ChangeDependencyGroupIdAndArtifactId`
- Adds explicit `after` text for the Java source spec to accept marker-only changes

## Context
- Failing CI run: https://github.com/openrewrite/rewrite-hibernate/actions/runs/24287753799
- Upstream issue: openrewrite/rewrite#7349

## Test plan
- [x] `MigrateToHibernate61Test.groupIdHibernateOrmRenamed` passes locally