### PR TITLE
Handle all original coordinates in chained ChangeDependency recipes

### DIFF
--- a/src/main/resources/META-INF/rewrite/hibernate-6.2.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.2.yml
@@ -48,4 +48,43 @@ recipeList:
       newGroupId: io.hypersistence
       newArtifactId: hypersistence-utils-hibernate-62
       newVersion: 3.7.x
+  # Handle pre-6.0 coordinates directly, since ChangeDependency is a ScanningRecipe
+  # and chained ChangeDependency calls across recipe versions cannot see each other's
+  # output during the scan phase
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-4
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-62
+      newVersion: 3.7.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-5
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-62
+      newVersion: 3.7.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-43
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-62
+      newVersion: 3.7.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-52
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-62
+      newVersion: 3.7.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-55
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-62
+      newVersion: 3.7.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-60
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-62
+      newVersion: 3.7.x
 

--- a/src/main/resources/META-INF/rewrite/hibernate-6.3.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.3.yml
@@ -47,4 +47,49 @@ recipeList:
       newGroupId: io.hypersistence
       newArtifactId: hypersistence-utils-hibernate-63
       newVersion: 3.8.x
+  # Handle earlier coordinates directly, since ChangeDependency is a ScanningRecipe
+  # and chained ChangeDependency calls across recipe versions cannot see each other's
+  # output during the scan phase
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: io.hypersistence
+      oldArtifactId: hypersistence-utils-hibernate-60
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-63
+      newVersion: 3.8.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-4
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-63
+      newVersion: 3.8.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-5
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-63
+      newVersion: 3.8.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-43
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-63
+      newVersion: 3.8.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-52
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-63
+      newVersion: 3.8.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-55
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-63
+      newVersion: 3.8.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.vladmihalcea
+      oldArtifactId: hibernate-types-60
+      newGroupId: io.hypersistence
+      newArtifactId: hypersistence-utils-hibernate-63
+      newVersion: 3.8.x
 

--- a/src/main/resources/META-INF/rewrite/hibernate-7.0.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-7.0.yml
@@ -33,3 +33,16 @@ recipeList:
       oldGroupId: org.hibernate.orm
       oldArtifactId: hibernate-jpamodelgen
       newArtifactId: hibernate-processor
+  # Handle pre-6.0 coordinates directly, since ChangeDependency is a ScanningRecipe
+  # and chained ChangeDependency calls across recipe versions cannot see each other's
+  # output during the scan phase
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-jpamodelgen
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-processor
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-jpamodelgen-jakarta
+      newGroupId: org.hibernate.orm
+      newArtifactId: hibernate-processor


### PR DESCRIPTION
## Summary

`ChangeDependency` is a `ScanningRecipe`. When the full Hibernate migration chain runs (e.g., `MigrateToHibernate70` → 66 → ... → 60), all `ScanningRecipe` instances scan the **same original source tree** before any edits are applied. This means a `ChangeDependency` in the 7.0 recipe cannot see the output of a `ChangeDependency` in the 6.0 recipe during its scan phase — its accumulator (version resolution, property mappings, etc.) comes up empty for targets that only exist after an earlier recipe's edit.

**Affected chains:**

1. **`hibernate-jpamodelgen` → `hibernate-processor`**: The 6.0 recipe changes `org.hibernate:hibernate-jpamodelgen` → `org.hibernate.orm:hibernate-jpamodelgen`, but the 7.0 recipe's scanner looks for `org.hibernate.orm:hibernate-jpamodelgen` in the original tree and doesn't find it. Projects jumping from Hibernate 5.x to 7.0 end up with `hibernate-jpamodelgen` instead of `hibernate-processor`.

2. **Hypersistence Utils triple chain**: `com.vladmihalcea:hibernate-types-*` → `hypersistence-utils-hibernate-60` (6.0) → `-62` (6.2) → `-63` (6.3). Each step only targets the immediately preceding coordinates, so projects starting from `vladmihalcea` or `-60` get stranded at an intermediate artifact name.

**Fix:** Add direct `ChangeDependency` entries for all original coordinates at each level of the chain, so the scanner finds them regardless of starting point.