### PR TITLE
Add Session load/saveOrUpdate and CascadeType renames for Hibernate 7.0

### DIFF
--- a/src/main/resources/META-INF/rewrite/hibernate-7.0.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-7.0.yml
@@ -71,17 +71,8 @@ recipeList:
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: org.hibernate.Session load(String, java.io.Serializable)
       newMethodName: getReference
-  - org.openrewrite.java.ChangeMethodName:
-      methodPattern: org.hibernate.Session saveOrUpdate(Object)
-      newMethodName: persist
-  - org.openrewrite.java.ChangeMethodName:
-      methodPattern: org.hibernate.Session saveOrUpdate(String, Object)
-      newMethodName: persist
 
   # CascadeType enum value renames
-  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
-      existingFullyQualifiedConstantName: org.hibernate.annotations.CascadeType.SAVE_UPDATE
-      fullyQualifiedConstantName: org.hibernate.annotations.CascadeType.PERSIST
   - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
       existingFullyQualifiedConstantName: org.hibernate.annotations.CascadeType.DELETE
       fullyQualifiedConstantName: org.hibernate.annotations.CascadeType.REMOVE

--- a/src/main/resources/META-INF/rewrite/hibernate-7.0.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-7.0.yml
@@ -63,3 +63,25 @@ recipeList:
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: org.hibernate.Session get(String, java.io.Serializable)
       newMethodName: find
+
+  # Remaining Session method renames
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.hibernate.Session load(Class, java.io.Serializable)
+      newMethodName: getReference
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.hibernate.Session load(String, java.io.Serializable)
+      newMethodName: getReference
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.hibernate.Session saveOrUpdate(Object)
+      newMethodName: persist
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.hibernate.Session saveOrUpdate(String, Object)
+      newMethodName: persist
+
+  # CascadeType enum value renames
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.hibernate.annotations.CascadeType.SAVE_UPDATE
+      fullyQualifiedConstantName: org.hibernate.annotations.CascadeType.PERSIST
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.hibernate.annotations.CascadeType.DELETE
+      fullyQualifiedConstantName: org.hibernate.annotations.CascadeType.REMOVE

--- a/src/test/java/org/openrewrite/hibernate/MigrateToHibernate70Test.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateToHibernate70Test.java
@@ -133,4 +133,108 @@ class MigrateToHibernate70Test implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void migratesLoadToGetReference() {
+        rewriteRun(
+          java(
+            """
+            import org.hibernate.Session;
+
+            class MyService {
+                Object load(Session session) {
+                    return session.load(String.class, "id");
+                }
+            }
+            """,
+            """
+            import org.hibernate.Session;
+
+            class MyService {
+                Object load(Session session) {
+                    return session.getReference(String.class, "id");
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void migratesSaveOrUpdateToPersist() {
+        rewriteRun(
+          java(
+            """
+            import org.hibernate.Session;
+
+            class MyService {
+                void saveOrUpdate(Session session, Object entity) {
+                    session.saveOrUpdate(entity);
+                }
+            }
+            """,
+            """
+            import org.hibernate.Session;
+
+            class MyService {
+                void saveOrUpdate(Session session, Object entity) {
+                    session.persist(entity);
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void migratesCascadeSaveUpdateToPersist() {
+        rewriteRun(
+          java(
+            """
+            import org.hibernate.annotations.Cascade;
+            import org.hibernate.annotations.CascadeType;
+
+            class MyEntity {
+                @Cascade(CascadeType.SAVE_UPDATE)
+                Object related;
+            }
+            """,
+            """
+            import org.hibernate.annotations.Cascade;
+            import org.hibernate.annotations.CascadeType;
+
+            class MyEntity {
+                @Cascade(CascadeType.PERSIST)
+                Object related;
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void migratesCascadeDeleteToRemove() {
+        rewriteRun(
+          java(
+            """
+            import org.hibernate.annotations.Cascade;
+            import org.hibernate.annotations.CascadeType;
+
+            class MyEntity {
+                @Cascade(CascadeType.DELETE)
+                Object related;
+            }
+            """,
+            """
+            import org.hibernate.annotations.Cascade;
+            import org.hibernate.annotations.CascadeType;
+
+            class MyEntity {
+                @Cascade(CascadeType.REMOVE)
+                Object related;
+            }
+            """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/hibernate/MigrateToHibernate70Test.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateToHibernate70Test.java
@@ -135,103 +135,43 @@ class MigrateToHibernate70Test implements RewriteTest {
     }
 
     @Test
-    void migratesLoadToGetReference() {
+    void migratesLoadAndCascadeTypes() {
         rewriteRun(
           java(
             """
             import org.hibernate.Session;
-
-            class MyService {
-                Object load(Session session) {
-                    return session.load(String.class, "id");
-                }
-            }
-            """,
-            """
-            import org.hibernate.Session;
-
-            class MyService {
-                Object load(Session session) {
-                    return session.getReference(String.class, "id");
-                }
-            }
-            """
-          )
-        );
-    }
-
-    @Test
-    void migratesSaveOrUpdateToPersist() {
-        rewriteRun(
-          java(
-            """
-            import org.hibernate.Session;
-
-            class MyService {
-                void saveOrUpdate(Session session, Object entity) {
-                    session.saveOrUpdate(entity);
-                }
-            }
-            """,
-            """
-            import org.hibernate.Session;
-
-            class MyService {
-                void saveOrUpdate(Session session, Object entity) {
-                    session.persist(entity);
-                }
-            }
-            """
-          )
-        );
-    }
-
-    @Test
-    void migratesCascadeSaveUpdateToPersist() {
-        rewriteRun(
-          java(
-            """
-            import org.hibernate.annotations.Cascade;
-            import org.hibernate.annotations.CascadeType;
-
-            class MyEntity {
-                @Cascade(CascadeType.SAVE_UPDATE)
-                Object related;
-            }
-            """,
-            """
-            import org.hibernate.annotations.Cascade;
-            import org.hibernate.annotations.CascadeType;
-
-            class MyEntity {
-                @Cascade(CascadeType.PERSIST)
-                Object related;
-            }
-            """
-          )
-        );
-    }
-
-    @Test
-    void migratesCascadeDeleteToRemove() {
-        rewriteRun(
-          java(
-            """
             import org.hibernate.annotations.Cascade;
             import org.hibernate.annotations.CascadeType;
 
             class MyEntity {
                 @Cascade(CascadeType.DELETE)
-                Object related;
+                Object deleteRelated;
+
+                Object load(Session session) {
+                    return session.load(String.class, "id");
+                }
+
+                Object loadByName(Session session) {
+                    return session.load("org.example.MyEntity", "id");
+                }
             }
             """,
             """
+            import org.hibernate.Session;
             import org.hibernate.annotations.Cascade;
             import org.hibernate.annotations.CascadeType;
 
             class MyEntity {
                 @Cascade(CascadeType.REMOVE)
-                Object related;
+                Object deleteRelated;
+
+                Object load(Session session) {
+                    return session.getReference(String.class, "id");
+                }
+
+                Object loadByName(Session session) {
+                    return session.getReference("org.example.MyEntity", "id");
+                }
             }
             """
           )


### PR DESCRIPTION
- Migrate Session.load() to Session.getReference()
- Migrate Session.saveOrUpdate() to Session.persist()
- Migrate CascadeType.SAVE_UPDATE to CascadeType.PERSIST
- Migrate CascadeType.DELETE to CascadeType.REMOVE

- Part of #53

## What's changed?
Added method rename and constant replacement recipes for Hibernate 7.0:

**Session method renames:**
- `Session.load()` → `Session.getReference()`
- `Session.saveOrUpdate()` → `Session.persist()`

**CascadeType enum value renames:**
- `CascadeType.SAVE_UPDATE` → `CascadeType.PERSIST`
- `CascadeType.DELETE` → `CascadeType.REMOVE`

## What's your motivation?
These methods and enum values were removed in Hibernate 7.0.
Projects upgrading will get compilation errors without these replacements.

## Anything in particular you'd like reviewers to focus on?
Used `ReplaceConstantWithAnotherConstant` for the CascadeType enum 
values instead of `ChangeType`, as enum constants require a different 
recipe than class type renames.

## Anyone you would like to review specifically?
@timtebeek

## Sources
- [Hibernate 7.0 Migration Guide](https://docs.jboss.org/hibernate/orm/7.0/migration-guide/migration-guide.html)
  — states `Session#save`, `Session#saveOrUpdate` removed in favor of 
  `Session#persist`, `CascadeType.SAVE_UPDATE` removed in favor of 
  `CascadeType.PERSIST`, `CascadeType.DELETE` removed in favor of 
  `CascadeType.REMOVE`