### PR TITLE
Stop renaming `hibernate-validator` to `org.hibernate.orm`

### DIFF
--- a/src/main/resources/META-INF/rewrite/hibernate-6.0.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.0.yml
@@ -134,8 +134,6 @@ recipeList:
   - org.openrewrite.maven.RemoveManagedDependency:
       groupId: org.hibernate
       artifactId: hibernate-entitymanager
-  # Hibernate Validator moved to its own `org.hibernate.validator` group ID, not `org.hibernate.orm`;
-  # rename it before the wildcard below so it is no longer matched as `org.hibernate:hibernate-*`.
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.hibernate
       oldArtifactId: hibernate-validator

--- a/src/main/resources/META-INF/rewrite/hibernate-6.0.yml
+++ b/src/main/resources/META-INF/rewrite/hibernate-6.0.yml
@@ -134,6 +134,13 @@ recipeList:
   - org.openrewrite.maven.RemoveManagedDependency:
       groupId: org.hibernate
       artifactId: hibernate-entitymanager
+  # Hibernate Validator moved to its own `org.hibernate.validator` group ID, not `org.hibernate.orm`;
+  # rename it before the wildcard below so it is no longer matched as `org.hibernate:hibernate-*`.
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-validator
+      newGroupId: org.hibernate.validator
+      newVersion: 8.0.x
   # Single glob for all remaining ORM artifacts — preserves shared version properties
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.hibernate

--- a/src/test/java/org/openrewrite/hibernate/MigrateToHibernate60Test.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateToHibernate60Test.java
@@ -115,11 +115,11 @@ class MigrateToHibernate60Test implements RewriteTest {
                 </dependencies>
               </project>
               """,
-            spec -> spec.after(after -> {
-                assertThat(after).contains("<groupId>org.hibernate.validator</groupId>");
-                assertThat(after).doesNotContain("<groupId>org.hibernate.orm</groupId>");
-                return after;
-            })
+            spec -> spec.after(after ->
+                assertThat(after)
+                    .contains("<groupId>org.hibernate.validator</groupId>")
+                    .doesNotContain("<groupId>org.hibernate.orm</groupId>")
+                    .actual())
           )
         );
     }

--- a/src/test/java/org/openrewrite/hibernate/MigrateToHibernate60Test.java
+++ b/src/test/java/org/openrewrite/hibernate/MigrateToHibernate60Test.java
@@ -21,6 +21,7 @@ import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 
@@ -91,6 +92,34 @@ class MigrateToHibernate60Test implements RewriteTest {
                 </project>
                 """
             )
+          )
+        );
+    }
+
+    @Test
+    void hibernateValidatorGetsItsOwnGroupIdNotOrm() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                <groupId>org.example</groupId>
+                <artifactId>a</artifactId>
+                <version>1.0.0</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-validator</artifactId>
+                    <version>6.2.5.Final</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            spec -> spec.after(after -> {
+                assertThat(after).contains("<groupId>org.hibernate.validator</groupId>");
+                assertThat(after).doesNotContain("<groupId>org.hibernate.orm</groupId>");
+                return after;
+            })
           )
         );
     }


### PR DESCRIPTION
## Summary

The greedy `hibernate-*` wildcard in `MigrateToHibernateDependencies60` was also matching `hibernate-validator`, moving it to the `org.hibernate.orm` group ID. The Bean Validation reference implementation actually lives under `org.hibernate.validator`, so this PR renames it explicitly before the wildcard runs — same pattern already in use for `hibernate-entitymanager`.

- Reported in [moderneinc/customer-requests#2455](https://github.com/moderneinc/customer-requests/issues/2455).

## Test plan
- [x] Added `MigrateToHibernate60Test#hibernateValidatorGetsItsOwnGroupIdNotOrm` asserting the group ID becomes `org.hibernate.validator` (and is not `org.hibernate.orm`)
- [x] `./gradlew test --tests org.openrewrite.hibernate.MigrateToHibernate60Test` passes