### PR TITLE
Expect hibernate-validator 8.0.4.Final in HibernateValidator80Test

### DIFF
--- a/src/test/java/org/openrewrite/hibernate/validator/HibernateValidator80Test.java
+++ b/src/test/java/org/openrewrite/hibernate/validator/HibernateValidator80Test.java
@@ -64,7 +64,7 @@ class HibernateValidator80Test implements RewriteTest {
                   <dependency>
                     <groupId>org.hibernate.validator</groupId>
                     <artifactId>hibernate-validator</artifactId>
-                    <version>8.0.3.Final</version>
+                    <version>8.0.4.Final</version>
                   </dependency>
                 </dependencies>
               </project>


### PR DESCRIPTION
## Problem
Scheduled CI failed in [run 28121927633](https://github.com/openrewrite/rewrite-hibernate/actions/runs/28121927633): `HibernateValidator80Test.changeDependency()` upgraded `hibernate-validator` to `8.0.4.Final` but the test expected `8.0.3.Final`.

```
org.opentest4j.AssertionFailedError: [Unexpected result in "pom.xml":
-      <version>8.0.3.Final</version>
+      <version>8.0.4.Final</version>
```

## Root cause
`hibernate-validator` **8.0.4.Final** was published to Maven Central (confirmed present; `<latest>` is now 9.1.1.Final). The recipe correctly upgrades to the newest `8.0.x` patch, so the hardcoded expectation is stale.

## Fix
Bump the expected version from `8.0.3.Final` to `8.0.4.Final`.