### PR TITLE
Assert hibernate-validator 8.0.x pattern instead of exact version

### DIFF
--- a/src/test/java/org/openrewrite/hibernate/validator/HibernateValidator80Test.java
+++ b/src/test/java/org/openrewrite/hibernate/validator/HibernateValidator80Test.java
@@ -20,6 +20,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class HibernateValidator80Test implements RewriteTest {
@@ -52,23 +53,11 @@ class HibernateValidator80Test implements RewriteTest {
                 </dependencies>
               </project>
               """,
-            """
-              <?xml version="1.0" encoding="UTF-8"?>
-              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-                <modelVersion>4.0.0</modelVersion>
-                <groupId>com.example</groupId>
-                <artifactId>demo</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
-                <dependencies>
-                  <dependency>
-                    <groupId>org.hibernate.validator</groupId>
-                    <artifactId>hibernate-validator</artifactId>
-                    <version>8.0.4.Final</version>
-                  </dependency>
-                </dependencies>
-              </project>
-              """
+            spec -> spec.after(actual ->
+              assertThat(actual)
+                .contains("<groupId>org.hibernate.validator</groupId>")
+                .containsPattern("<version>8\\.0\\.\\d+\\.Final</version>")
+                .actual())
           )
         );
     }


### PR DESCRIPTION
- `HibernateValidator80Test.changeDependency()` pinned `8.0.4.Final` as the expected upgrade result, so [CI broke](https://github.com/openrewrite/rewrite-hibernate/actions/runs/30213736559) as soon as `8.0.5.Final` was released — the same breakage #89 already patched once.

Use the `spec.after(...)` + AssertJ idiom already used in `AbstractMigrateToHibernateWithHypersistenceTest`, matching `<version>8\.0\.\d+\.Final</version>` so future 8.0.x patch releases don't fail the build.